### PR TITLE
Session metadata fulfilled field

### DIFF
--- a/astro/src/pages/admin.astro
+++ b/astro/src/pages/admin.astro
@@ -66,6 +66,7 @@ type CheckoutSessionSummary = Pick<
     | "currency"
 > & {
     order_id: string | null
+    fulfilled: boolean
     amount_discount: number | null
     line_items: CheckoutSessionLineItemSummary[]
 }
@@ -155,6 +156,32 @@ let newsletterContacts: NewsletterContact[] = []
 let activeProducts: StripeProduct[] = []
 const apiUrl = import.meta.env.PUBLIC_API_URL
 const adminSecret = import.meta.env.ADMIN_API_SECRET
+let fulfilledUpdateStatus: "success" | "error" | null = null
+
+if (Astro.request.method === "POST") {
+    const formData = await Astro.request.formData()
+    const formAction = formData.get("action")
+    const sessionIdValue = formData.get("sessionId")
+    const sessionId = typeof sessionIdValue === "string" ? sessionIdValue.trim() : ""
+
+    if (formAction === "set-fulfilled" && sessionId && apiUrl && adminSecret) {
+        try {
+            const res = await fetch(
+                apiUrl + `/sessions/${encodeURIComponent(sessionId)}/fulfilled`,
+                {
+                    method: "PATCH",
+                    headers: { "X-Admin-Secret": adminSecret },
+                }
+            )
+            fulfilledUpdateStatus = res.ok ? "success" : "error"
+        } catch {
+            fulfilledUpdateStatus = "error"
+        }
+    } else {
+        fulfilledUpdateStatus = "error"
+    }
+}
+
 if (apiUrl) {
     try {
         const res = await fetch(apiUrl + "/products", {
@@ -231,6 +258,17 @@ if (apiUrl && adminSecret) {
         <p class="mt-4">
             You are authenticated as <strong>{sessionClaims.email || "admin user"}</strong>.
         </p>
+        {fulfilledUpdateStatus === "success" ? (
+            <p class="mt-3 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                Session marked as fulfilled.
+            </p>
+        ) : fulfilledUpdateStatus === "error" ? (
+            <p class="mt-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                Could not mark this session as fulfilled.
+            </p>
+        ) : (
+            <></>
+        )}
         <section class="mt-10" aria-labelledby="active-products-heading">
             <h2 id="active-products-heading" class="text-xl font-semibold">
                 Active products
@@ -316,7 +354,7 @@ if (apiUrl && adminSecret) {
             {checkoutSessions.length > 0 ? (
                 <div class="mt-4 overflow-x-auto pb-1">
                     <div class="w-max min-w-full rounded border border-gray-200 bg-white">
-                    <table class="min-w-[1240px] w-full border-collapse">
+                    <table class="min-w-[1360px] w-full border-collapse">
                         <thead>
                             <tr class="border-b border-gray-200 bg-white">
                                 <th class="px-3 py-2 text-left text-xs md:px-4 md:text-sm font-medium text-gray-600 whitespace-nowrap">
@@ -327,6 +365,9 @@ if (apiUrl && adminSecret) {
                                 </th>
                                 <th class="px-3 py-2 text-left text-xs md:px-4 md:text-sm font-medium text-gray-600 whitespace-nowrap">
                                     Order ID
+                                </th>
+                                <th class="px-3 py-2 text-left text-xs md:px-4 md:text-sm font-medium text-gray-600 whitespace-nowrap">
+                                    Fulfilled
                                 </th>
                                 <th class="px-3 py-2 text-left text-xs md:px-4 md:text-sm font-medium text-gray-600 whitespace-nowrap">
                                     Customer
@@ -362,6 +403,30 @@ if (apiUrl && adminSecret) {
                                     </td>
                                     <td class="px-3 py-2 text-gray-800 text-xs md:px-4 md:text-sm whitespace-nowrap">
                                         {session.order_id ?? "—"}
+                                    </td>
+                                    <td class="px-3 py-2 text-gray-800 text-xs md:px-4 md:text-sm whitespace-nowrap">
+                                        {session.fulfilled ? (
+                                            <span class="font-medium">Yes</span>
+                                        ) : (
+                                            <form method="POST">
+                                                <input
+                                                    type="hidden"
+                                                    name="action"
+                                                    value="set-fulfilled"
+                                                />
+                                                <input
+                                                    type="hidden"
+                                                    name="sessionId"
+                                                    value={session.id}
+                                                />
+                                                <button
+                                                    type="submit"
+                                                    class="rounded border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 transition-colors duration-300 md:hover:border-gray-700 md:hover:text-gray-900"
+                                                >
+                                                    Set as fulfilled
+                                                </button>
+                                            </form>
+                                        )}
                                     </td>
                                     <td class="px-3 py-2 text-gray-800 text-xs md:px-4 md:text-sm break-all">
                                         {session.customer_email ? (

--- a/serverless/src/actions/stripe_listCheckoutSessions.ts
+++ b/serverless/src/actions/stripe_listCheckoutSessions.ts
@@ -19,6 +19,7 @@ export type CheckoutSessionSummary = Pick<
     | "currency"
 > & {
     order_id: string | null
+    fulfilled: boolean
     amount_discount: number | null
     line_items: CheckoutSessionLineItemSummary[]
 }
@@ -57,6 +58,7 @@ export const listCheckoutSessions = async (params?: {
                 id: session.id,
                 created: session.created,
                 order_id: session.metadata?.orderNumber ?? null,
+                fulfilled: session.metadata?.fulfilled === "true",
                 status: session.status,
                 payment_status: session.payment_status,
                 customer_email: session.customer_details?.email ?? session.customer_email,

--- a/serverless/src/actions/stripe_setCheckoutSessionFulfilled.ts
+++ b/serverless/src/actions/stripe_setCheckoutSessionFulfilled.ts
@@ -1,0 +1,29 @@
+import { initialiseClient } from "./stripe_initialiseClient"
+
+export const setCheckoutSessionFulfilled = async (params: {
+    sessionId: string
+}): Promise<{ success: boolean; error?: string }> => {
+    try {
+        const sessionId = params.sessionId.trim()
+        if (!sessionId) {
+            return { success: false, error: "Missing session id" }
+        }
+
+        const stripe = await initialiseClient()
+        const session = await stripe.checkout.sessions.retrieve(sessionId)
+
+        const metadata = {
+            ...(session.metadata ?? {}),
+            fulfilled: "true",
+        }
+
+        await stripe.checkout.sessions.update(sessionId, {
+            metadata,
+        })
+
+        return { success: true }
+    } catch (error) {
+        console.error("Failed to set checkout session fulfilled metadata", error)
+        return { success: false, error: "Failed to set fulfilled metadata" }
+    }
+}

--- a/serverless/src/lambdas/api_stripeSetCheckoutSessionFulfilled.ts
+++ b/serverless/src/lambdas/api_stripeSetCheckoutSessionFulfilled.ts
@@ -1,0 +1,50 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda"
+
+import { setCheckoutSessionFulfilled } from "../actions/stripe_setCheckoutSessionFulfilled"
+
+const corsHeaders = {
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "*",
+}
+
+export const handler = async (
+    event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+    const adminSecret = process.env.ADMIN_API_SECRET
+    const providedSecret =
+        event.headers?.["X-Admin-Secret"] ?? event.headers?.["x-admin-secret"]
+
+    if (!adminSecret || providedSecret !== adminSecret) {
+        return {
+            statusCode: 401,
+            body: JSON.stringify({ error: "Unauthorized" }),
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+    }
+
+    const sessionId = event.pathParameters?.sessionId
+    if (!sessionId) {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({ error: "Missing session id" }),
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+    }
+
+    const { success, error } = await setCheckoutSessionFulfilled({ sessionId })
+
+    if (!success) {
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: error ?? "Failed to set fulfilled metadata" }),
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+    }
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ success: true }),
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+    }
+}

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -733,6 +733,38 @@ Resources:
                 EntryPoints:
                     - src/lambdas/api_stripeListPromotionCodes.ts
 
+    StripeSetCheckoutSessionFulfilledFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+            FunctionName: !Sub ${AWS::StackName}-StripeSetCheckoutSessionFulfilled
+            Handler: src/lambdas/api_stripeSetCheckoutSessionFulfilled.handler
+            Events:
+                SetCheckoutSessionFulfilled:
+                    Type: Api
+                    Properties:
+                        RestApiId: !Ref ApiGateway
+                        Path: /sessions/{sessionId}/fulfilled
+                        Method: PATCH
+            Environment:
+                Variables:
+                    ADMIN_API_SECRET: "{{resolve:ssm:ADMIN_API_SECRET}}"
+            Policies:
+                - Statement:
+                      - Sid: readParameterStore
+                        Effect: Allow
+                        Action:
+                            - SSM:GetParameter
+                        Resource:
+                            - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/STRIPE_SECRET_KEY
+                            - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/ADMIN_API_SECRET
+        Metadata:
+            BuildMethod: esbuild
+            BuildProperties:
+                Minify: true
+                Target: "es2020"
+                EntryPoints:
+                    - src/lambdas/api_stripeSetCheckoutSessionFulfilled.ts
+
     StripeSynchroniseProductsFunction:
         Type: AWS::Serverless::Function
         Properties:


### PR DESCRIPTION
Adds a "fulfilled" field to checkout session metadata, allowing admins to mark sessions as fulfilled via the admin UI.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-fd542ac2-2342-4205-82f5-cb0c72cb699c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd542ac2-2342-4205-82f5-cb0c72cb699c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

