### PR TITLE
P5 sketches page

### DIFF
--- a/astro/.gitignore
+++ b/astro/.gitignore
@@ -25,5 +25,3 @@ pnpm-debug.log*
 
 # netlify
 .netlify/
-
-src/pages/sketches/

--- a/astro/src/content/config.ts
+++ b/astro/src/content/config.ts
@@ -1,5 +1,10 @@
 import { z, defineCollection } from "astro:content"
 
+const sketchControlsSchema = z.object({
+    noiseSeed: z.number().optional(),
+    randomSeed: z.number().optional(),
+})
+
 const artworksCollection = defineCollection({
     type: "data",
     schema: z.object({
@@ -10,6 +15,16 @@ const artworksCollection = defineCollection({
     }),
 })
 
+const sketchesCollection = defineCollection({
+    type: "data",
+    schema: z.object({
+        title: z.string(),
+        date: z.string(),
+        defaultControls: sketchControlsSchema.optional(),
+    }),
+})
+
 export const collections = {
     artworks: artworksCollection,
+    sketches: sketchesCollection,
 }

--- a/astro/src/content/sketches/cone-lines.json
+++ b/astro/src/content/sketches/cone-lines.json
@@ -1,0 +1,8 @@
+{
+    "title": "Cone Lines",
+    "date": "2026-03-02",
+    "defaultControls": {
+        "noiseSeed": 1000,
+        "randomSeed": 4321
+    }
+}

--- a/astro/src/content/sketches/cone-lines.json
+++ b/astro/src/content/sketches/cone-lines.json
@@ -2,7 +2,7 @@
     "title": "Cone Lines",
     "date": "2026-03-02",
     "defaultControls": {
-        "noiseSeed": 1000,
-        "randomSeed": 4321
+        "noiseSeed": 936007,
+        "randomSeed": 42548
     }
 }

--- a/astro/src/content/sketches/flow-field.json
+++ b/astro/src/content/sketches/flow-field.json
@@ -1,0 +1,8 @@
+{
+    "title": "Flow Field",
+    "date": "2026-02-28",
+    "defaultControls": {
+        "noiseSeed": 1823,
+        "randomSeed": 45678
+    }
+}

--- a/astro/src/content/sketches/fractal1.json
+++ b/astro/src/content/sketches/fractal1.json
@@ -1,0 +1,8 @@
+{
+    "title": "Fractal 1",
+    "date": "2026-03-01",
+    "defaultControls": {
+        "noiseSeed": 12345,
+        "randomSeed": 78901
+    }
+}

--- a/astro/src/content/sketches/noise-dunes.json
+++ b/astro/src/content/sketches/noise-dunes.json
@@ -1,0 +1,8 @@
+{
+    "title": "Noise Dunes",
+    "date": "2026-02-20",
+    "defaultControls": {
+        "noiseSeed": 927,
+        "randomSeed": 29384
+    }
+}

--- a/astro/src/layouts/SketchLayout.astro
+++ b/astro/src/layouts/SketchLayout.astro
@@ -1,0 +1,28 @@
+---
+import { ClientRouter } from "astro:transitions"
+import GlobalStyles from "@components/GlobalStyles.astro"
+
+interface Props {
+    title: string
+    description?: string
+}
+
+const { title, description = "Interactive p5.js sketch." } = Astro.props
+---
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="description" content={description} />
+        <meta name="robots" content="noindex, nofollow" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+        <title>{title}</title>
+        <ClientRouter />
+    </head>
+    <body class="m-0 h-screen w-screen overflow-hidden p-0">
+        <GlobalStyles />
+        <slot />
+    </body>
+</html>

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -186,7 +186,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                                 <button
                                     type="button"
                                     data-control-reset
-                                    class="rounded border border-gray-800 bg-gray-800 px-3 py-2 text-sm font-medium text-white"
+                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
                                 >
                                     Reset
                                 </button>

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -1,16 +1,41 @@
 ---
-export const prerender = false
-
 import BaseLayout from "@layouts/BaseLayout.astro"
-import { getLatestSketch, getSketchBySlug, sketchRegistry } from "../../sketches/registry"
+import { getCollection } from "astro:content"
 
-const { slug = "" } = Astro.params
-const selectedSketch = getSketchBySlug(slug)
-const latestSketch = getLatestSketch()
-
-if (!selectedSketch) {
-    Astro.response.status = 404
+type SketchItem = {
+    slug: string
+    title: string
+    date: string
+    defaultControls?: { noiseSeed?: number; randomSeed?: number }
 }
+
+export async function getStaticPaths() {
+    const entries = await getCollection("sketches")
+    const sorted = [...entries].sort(
+        (a, b) => Date.parse(b.data.date) - Date.parse(a.data.date),
+    )
+    const allSketches: SketchItem[] = sorted.map(entry => ({
+        slug: entry.id,
+        title: entry.data.title,
+        date: entry.data.date,
+        defaultControls: entry.data.defaultControls,
+    }))
+
+    return sorted.map(entry => ({
+        params: { slug: entry.id },
+        props: {
+            sketch: {
+                slug: entry.id,
+                title: entry.data.title,
+                date: entry.data.date,
+                defaultControls: entry.data.defaultControls,
+            } satisfies SketchItem,
+            allSketches,
+        },
+    }))
+}
+
+const { sketch, allSketches } = Astro.props
 
 const dateFormatter = new Intl.DateTimeFormat("en-GB", {
     day: "2-digit",
@@ -24,171 +49,158 @@ const formatSketchDate = (value: string): string => {
     return dateFormatter.format(new Date(parsedDate))
 }
 
-const pageTitle = selectedSketch ? `${selectedSketch.title} | Sketches` : "Sketch not found | Sketches"
-const pageDescription = selectedSketch
-    ? `Interactive p5 sketch: ${selectedSketch.title}.`
-    : "Requested sketch was not found."
+const defaults = sketch.defaultControls ?? {}
+const defaultNoiseSeed = defaults.noiseSeed ?? 1234
+const defaultRandomSeed = defaults.randomSeed ?? 5678
+
+const pageTitle = `${sketch.title} | Sketches`
+const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription} hideFooter={true} noIndex={true}>
     <div class="w-full h-[calc(100dvh-80px)]">
-        {selectedSketch ? (
-            <section
-                data-sketch-page-root
-                data-sketch-slug={selectedSketch.slug}
-                class="max-w-screen-2xl mx-auto h-full"
-            >
-                <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
-                    <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
-                        <div class="border-b border-gray-200 px-4 py-4">
-                            <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
-                            <p class="text-sm font-medium text-gray-800 mt-1">
-                                {sketchRegistry.length} total
-                            </p>
-                        </div>
-                        <nav class="flex-1 min-h-0 overflow-y-auto p-2">
-                            {sketchRegistry.map((sketch) => (
-                                <a
-                                    href={`/sketches/${sketch.slug}`}
-                                    class={`block rounded-md px-3 py-2 mb-2 transition-colors duration-200 ${
-                                        sketch.slug === selectedSketch.slug
-                                            ? "bg-gray-800 text-white"
-                                            : "text-gray-700 md:hover:bg-gray-200"
+        <section
+            data-sketch-page-root
+            data-sketch-slug={sketch.slug}
+            data-default-noise-seed={defaultNoiseSeed}
+            data-default-random-seed={defaultRandomSeed}
+            class="max-w-screen-2xl mx-auto h-full"
+        >
+            <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
+                <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
+                    <div class="border-b border-gray-200 px-4 py-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
+                        <p class="text-sm font-medium text-gray-800 mt-1">
+                            {allSketches.length} total
+                        </p>
+                    </div>
+                    <nav class="flex-1 min-h-0 overflow-y-auto p-2">
+                        {allSketches.map((s) => (
+                            <a
+                                href={`/sketches/${s.slug}`}
+                                class={`block rounded-md px-3 py-2 mb-2 transition-colors duration-200 ${
+                                    s.slug === sketch.slug
+                                        ? "bg-gray-800 text-white"
+                                        : "text-gray-700 md:hover:bg-gray-200"
+                                }`}
+                            >
+                                <span class="block text-sm font-semibold">{s.title}</span>
+                                <span
+                                    class={`block text-xs mt-0.5 ${
+                                        s.slug === sketch.slug
+                                            ? "text-gray-200"
+                                            : "text-gray-500"
                                     }`}
                                 >
-                                    <span class="block text-sm font-semibold">{sketch.title}</span>
+                                    {formatSketchDate(s.date)}
+                                </span>
+                            </a>
+                        ))}
+                    </nav>
+                </aside>
+
+                <div class="flex min-h-0 flex-1 flex-col">
+                    <div class="md:hidden border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketch</p>
+                            <h1 class="text-base font-semibold text-gray-900">{sketch.title}</h1>
+                        </div>
+                        <button
+                            type="button"
+                            data-sketch-menu-toggle
+                            class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                        >
+                            Menu
+                        </button>
+                    </div>
+
+                    <div
+                        data-sketch-menu-panel
+                        class="hidden md:hidden fixed inset-0 z-50 bg-white px-4 pt-20 pb-6 overflow-y-auto"
+                    >
+                        <div class="flex items-center justify-between mb-4">
+                            <h2 class="text-lg font-semibold text-gray-900">Sketches</h2>
+                            <button
+                                type="button"
+                                data-sketch-menu-close
+                                class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                            >
+                                Close
+                            </button>
+                        </div>
+                        <nav class="space-y-2">
+                            {allSketches.map((s) => (
+                                <a
+                                    data-sketch-menu-link
+                                    href={`/sketches/${s.slug}`}
+                                    class={`block rounded-md px-3 py-2 ${
+                                        s.slug === sketch.slug
+                                            ? "bg-gray-800 text-white"
+                                            : "bg-gray-100 text-gray-800"
+                                    }`}
+                                >
+                                    <span class="block text-sm font-semibold">{s.title}</span>
                                     <span
                                         class={`block text-xs mt-0.5 ${
-                                            sketch.slug === selectedSketch.slug
+                                            s.slug === sketch.slug
                                                 ? "text-gray-200"
                                                 : "text-gray-500"
                                         }`}
                                     >
-                                        {formatSketchDate(sketch.date)}
+                                        {formatSketchDate(s.date)}
                                     </span>
                                 </a>
                             ))}
                         </nav>
-                    </aside>
+                    </div>
 
-                    <div class="flex min-h-0 flex-1 flex-col">
-                        <div class="md:hidden border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-                            <div>
-                                <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketch</p>
-                                <h1 class="text-base font-semibold text-gray-900">{selectedSketch.title}</h1>
-                            </div>
-                            <button
-                                type="button"
-                                data-sketch-menu-toggle
-                                class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
-                            >
-                                Menu
-                            </button>
-                        </div>
+                    <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-3 p-3 md:gap-4 md:p-4">
+                        <section class="rounded-lg border border-gray-200 bg-white p-3 md:p-4">
+                            <div class="flex flex-wrap items-end gap-3 md:gap-4">
+                                <label class="flex flex-col text-sm text-gray-800">
+                                    <span class="mb-1">Noise seed</span>
+                                    <input
+                                        data-control-noise-seed
+                                        type="number"
+                                        class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
+                                    />
+                                </label>
 
-                        <div
-                            data-sketch-menu-panel
-                            class="hidden md:hidden fixed inset-0 z-50 bg-white px-4 pt-20 pb-6 overflow-y-auto"
-                        >
-                            <div class="flex items-center justify-between mb-4">
-                                <h2 class="text-lg font-semibold text-gray-900">Sketches</h2>
+                                <label class="flex flex-col text-sm text-gray-800">
+                                    <span class="mb-1">Random seed</span>
+                                    <input
+                                        data-control-random-seed
+                                        type="number"
+                                        class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
+                                    />
+                                </label>
+
                                 <button
                                     type="button"
-                                    data-sketch-menu-close
-                                    class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                                    data-control-randomize-seeds
+                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
                                 >
-                                    Close
+                                    Randomize seeds
+                                </button>
+
+                                <button
+                                    type="button"
+                                    data-control-reset
+                                    class="rounded border border-gray-800 bg-gray-800 px-3 py-2 text-sm font-medium text-white"
+                                >
+                                    Reset
                                 </button>
                             </div>
-                            <nav class="space-y-2">
-                                {sketchRegistry.map((sketch) => (
-                                    <a
-                                        data-sketch-menu-link
-                                        href={`/sketches/${sketch.slug}`}
-                                        class={`block rounded-md px-3 py-2 ${
-                                            sketch.slug === selectedSketch.slug
-                                                ? "bg-gray-800 text-white"
-                                                : "bg-gray-100 text-gray-800"
-                                        }`}
-                                    >
-                                        <span class="block text-sm font-semibold">{sketch.title}</span>
-                                        <span
-                                            class={`block text-xs mt-0.5 ${
-                                                sketch.slug === selectedSketch.slug
-                                                    ? "text-gray-200"
-                                                    : "text-gray-500"
-                                            }`}
-                                        >
-                                            {formatSketchDate(sketch.date)}
-                                        </span>
-                                    </a>
-                                ))}
-                            </nav>
-                        </div>
+                        </section>
 
-                        <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-3 p-3 md:gap-4 md:p-4">
-                            <section class="rounded-lg border border-gray-200 bg-white p-3 md:p-4">
-                                <div class="flex flex-wrap items-end gap-3 md:gap-4">
-                                    <label class="flex flex-col text-sm text-gray-800">
-                                        <span class="mb-1">Noise seed</span>
-                                        <input
-                                            data-control-noise-seed
-                                            type="number"
-                                            class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
-                                        />
-                                    </label>
-
-                                    <label class="flex flex-col text-sm text-gray-800">
-                                        <span class="mb-1">Random seed</span>
-                                        <input
-                                            data-control-random-seed
-                                            type="number"
-                                            class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
-                                        />
-                                    </label>
-
-                                    <button
-                                        type="button"
-                                        data-control-randomize-seeds
-                                        class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
-                                    >
-                                        Randomize seeds
-                                    </button>
-
-                                    <button
-                                        type="button"
-                                        data-control-reset
-                                        class="rounded border border-gray-800 bg-gray-800 px-3 py-2 text-sm font-medium text-white"
-                                    >
-                                        Reset
-                                    </button>
-                                </div>
-                            </section>
-
-                            <section class="min-h-0 rounded-lg border border-gray-200 bg-white">
-                                <div data-sketch-canvas class="h-full min-h-[340px] w-full"></div>
-                                <p data-sketch-error class="hidden px-4 py-3 text-sm text-red-700"></p>
-                            </section>
-                        </div>
+                        <section class="min-h-0 rounded-lg border border-gray-200 bg-white">
+                            <div data-sketch-canvas class="h-full min-h-[340px] w-full"></div>
+                            <p data-sketch-error class="hidden px-4 py-3 text-sm text-red-700"></p>
+                        </section>
                     </div>
                 </div>
-            </section>
-        ) : (
-            <section class="max-w-screen-md mx-auto px-4 py-10 md:py-14">
-                <h1 class="text-2xl md:text-4xl font-bold">Sketch not found</h1>
-                <p class="mt-3 text-gray-700">
-                    The sketch you requested does not exist.
-                </p>
-                {latestSketch ? (
-                    <a
-                        href={`/sketches/${latestSketch.slug}`}
-                        class="inline-flex items-center justify-center rounded border border-gray-800 bg-gray-800 px-4 py-2 text-white font-medium mt-6"
-                    >
-                        Go to latest sketch
-                    </a>
-                ) : null}
-            </section>
-        )}
+            </div>
+        </section>
     </div>
 </BaseLayout>
 

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -129,15 +129,6 @@ const pageDescription = selectedSketch
                         <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-3 p-3 md:gap-4 md:p-4">
                             <section class="rounded-lg border border-gray-200 bg-white p-3 md:p-4">
                                 <div class="flex flex-wrap items-end gap-3 md:gap-4">
-                                    <label class="inline-flex items-center gap-2 text-sm text-gray-800">
-                                        <input
-                                            data-control-reverse
-                                            type="checkbox"
-                                            class="h-4 w-4 rounded border-gray-300 text-gray-800 focus:ring-gray-500"
-                                        />
-                                        Reverse
-                                    </label>
-
                                     <label class="flex flex-col text-sm text-gray-800">
                                         <span class="mb-1">Noise seed</span>
                                         <input

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -138,12 +138,21 @@ const pageDescription = selectedSketch
                                         />
                                     </label>
 
+                                    <label class="flex flex-col text-sm text-gray-800">
+                                        <span class="mb-1">Random seed</span>
+                                        <input
+                                            data-control-random-seed
+                                            type="number"
+                                            class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
+                                        />
+                                    </label>
+
                                     <button
                                         type="button"
-                                        data-control-random-seed
+                                        data-control-randomize-seeds
                                         class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
                                     >
-                                        Random seed
+                                        Randomize seeds
                                     </button>
 
                                     <button

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -55,7 +55,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
             class="flex h-full w-full min-h-0 flex-col"
         >
             <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
-                <aside class="flex min-w-0 flex-col h-full min-h-0 bg-gray-50">
+                <aside class="flex min-w-0 flex-col h-full min-h-0">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a
@@ -72,7 +72,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
 
                 <div class="flex min-h-0 flex-1 flex-col">
                     <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-2 p-2">
-                        <section class="shrink-0 bg-white">
+                        <section class="shrink-0">
                             <div class="flex flex-col gap-2">
                                 <div class="flex items-end gap-3 md:gap-4">
                                     <label class="flex flex-col text-sm text-gray-800">
@@ -122,7 +122,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                             </div>
                         </section>
 
-                        <section class="min-h-0 flex-1 border border-gray-200 bg-white overflow-hidden">
+                        <section class="min-h-0 flex-1 overflow-hidden">
                             <div data-sketch-canvas class="h-full w-full min-h-[200px]"></div>
                             <p data-sketch-error class="hidden px-4 py-3 text-sm text-red-700"></p>
                         </section>

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -55,7 +55,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
             class="flex h-full w-full min-h-0 flex-col"
         >
             <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
-                <aside class="flex min-w-0 flex-col h-full min-h-0 border-r border-gray-200 bg-gray-50">
+                <aside class="flex min-w-0 flex-col h-full min-h-0 bg-gray-50">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a
@@ -72,7 +72,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
 
                 <div class="flex min-h-0 flex-1 flex-col">
                     <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-2 p-2">
-                        <section class="shrink-0 border-b border-gray-200 bg-white p-2">
+                        <section class="shrink-0 bg-white">
                             <div class="flex flex-col gap-2">
                                 <div class="flex items-end gap-3 md:gap-4">
                                     <label class="flex flex-col text-sm text-gray-800">

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -37,18 +37,6 @@ export async function getStaticPaths() {
 
 const { sketch, allSketches } = Astro.props
 
-const dateFormatter = new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-})
-
-const formatSketchDate = (value: string): string => {
-    const parsedDate = Date.parse(value)
-    if (Number.isNaN(parsedDate)) return value
-    return dateFormatter.format(new Date(parsedDate))
-}
-
 const defaults = sketch.defaultControls ?? {}
 const defaultNoiseSeed = defaults.noiseSeed ?? 1234
 const defaultRandomSeed = defaults.randomSeed ?? 5678
@@ -66,94 +54,23 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
             data-default-random-seed={defaultRandomSeed}
             class="flex h-full w-full min-h-0 flex-col"
         >
-            <div class="grid min-h-0 flex-1 md:grid-cols-[260px_1fr]">
-                <aside class="hidden md:flex md:flex-col md:h-full border-r border-gray-200 bg-gray-50 min-h-0">
-                    <div class="border-b border-gray-200 px-4 py-4">
-                        <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
-                        <p class="text-sm font-medium text-gray-800 mt-1">
-                            {allSketches.length} total
-                        </p>
-                    </div>
+            <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
+                <aside class="flex min-w-0 flex-col h-full min-h-0 border-r border-gray-200 bg-gray-50">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a
                                 href={`/sketches/${s.slug}`}
-                                class={`block rounded-md px-3 py-2 mb-2 transition-colors duration-200 ${
-                                    s.slug === sketch.slug
-                                        ? "bg-gray-800 text-white"
-                                        : "text-gray-700 md:hover:bg-gray-200"
+                                class={`block min-w-0 py-1 mb-0.5 text-blue-600 hover:underline ${
+                                    s.slug === sketch.slug ? "underline font-medium" : ""
                                 }`}
                             >
-                                <span class="block text-sm font-semibold">{s.title}</span>
-                                <span
-                                    class={`block text-xs mt-0.5 ${
-                                        s.slug === sketch.slug
-                                            ? "text-gray-200"
-                                            : "text-gray-500"
-                                    }`}
-                                >
-                                    {formatSketchDate(s.date)}
-                                </span>
+                                <span class="block break-words text-sm">{s.title}</span>
                             </a>
                         ))}
                     </nav>
                 </aside>
 
                 <div class="flex min-h-0 flex-1 flex-col">
-                    <div class="md:hidden border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-                        <div>
-                            <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketch</p>
-                            <h1 class="text-base font-semibold text-gray-900">{sketch.title}</h1>
-                        </div>
-                        <button
-                            type="button"
-                            data-sketch-menu-toggle
-                            class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
-                        >
-                            Menu
-                        </button>
-                    </div>
-
-                    <div
-                        data-sketch-menu-panel
-                        class="hidden md:hidden fixed inset-0 z-50 bg-white px-4 pt-20 pb-6 overflow-y-auto"
-                    >
-                        <div class="flex items-center justify-between mb-4">
-                            <h2 class="text-lg font-semibold text-gray-900">Sketches</h2>
-                            <button
-                                type="button"
-                                data-sketch-menu-close
-                                class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
-                            >
-                                Close
-                            </button>
-                        </div>
-                        <nav class="space-y-2">
-                            {allSketches.map((s) => (
-                                <a
-                                    data-sketch-menu-link
-                                    href={`/sketches/${s.slug}`}
-                                    class={`block rounded-md px-3 py-2 ${
-                                        s.slug === sketch.slug
-                                            ? "bg-gray-800 text-white"
-                                            : "bg-gray-100 text-gray-800"
-                                    }`}
-                                >
-                                    <span class="block text-sm font-semibold">{s.title}</span>
-                                    <span
-                                        class={`block text-xs mt-0.5 ${
-                                            s.slug === sketch.slug
-                                                ? "text-gray-200"
-                                                : "text-gray-500"
-                                        }`}
-                                    >
-                                        {formatSketchDate(s.date)}
-                                    </span>
-                                </a>
-                            ))}
-                        </nav>
-                    </div>
-
                     <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-2 p-2">
                         <section class="shrink-0 border-b border-gray-200 bg-white p-2">
                             <div class="flex flex-wrap items-end gap-3 md:gap-4">
@@ -180,7 +97,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                                     data-control-randomize-seeds
                                     class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
                                 >
-                                    Randomize seeds
+                                    Randomise
                                 </button>
 
                                 <button
@@ -196,7 +113,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                                     data-control-save-image
                                     class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
                                 >
-                                    Save image
+                                    Save
                                 </button>
                             </div>
                         </section>

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -1,0 +1,199 @@
+---
+export const prerender = false
+
+import BaseLayout from "@layouts/BaseLayout.astro"
+import { getLatestSketch, getSketchBySlug, sketchRegistry } from "../../sketches/registry"
+
+const { slug = "" } = Astro.params
+const selectedSketch = getSketchBySlug(slug)
+const latestSketch = getLatestSketch()
+
+if (!selectedSketch) {
+    Astro.response.status = 404
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+})
+
+const formatSketchDate = (value: string): string => {
+    const parsedDate = Date.parse(value)
+    if (Number.isNaN(parsedDate)) return value
+    return dateFormatter.format(new Date(parsedDate))
+}
+
+const pageTitle = selectedSketch ? `${selectedSketch.title} | Sketches` : "Sketch not found | Sketches"
+const pageDescription = selectedSketch
+    ? `Interactive p5 sketch: ${selectedSketch.title}.`
+    : "Requested sketch was not found."
+---
+
+<BaseLayout title={pageTitle} description={pageDescription} hideFooter={true} noIndex={true}>
+    <div class="w-full h-[calc(100dvh-80px)]">
+        {selectedSketch ? (
+            <section
+                data-sketch-page-root
+                data-sketch-slug={selectedSketch.slug}
+                class="max-w-screen-2xl mx-auto h-full"
+            >
+                <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
+                    <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
+                        <div class="border-b border-gray-200 px-4 py-4">
+                            <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
+                            <p class="text-sm font-medium text-gray-800 mt-1">
+                                {sketchRegistry.length} total
+                            </p>
+                        </div>
+                        <nav class="flex-1 min-h-0 overflow-y-auto p-2">
+                            {sketchRegistry.map((sketch) => (
+                                <a
+                                    href={`/sketches/${sketch.slug}`}
+                                    class={`block rounded-md px-3 py-2 mb-2 transition-colors duration-200 ${
+                                        sketch.slug === selectedSketch.slug
+                                            ? "bg-gray-800 text-white"
+                                            : "text-gray-700 md:hover:bg-gray-200"
+                                    }`}
+                                >
+                                    <span class="block text-sm font-semibold">{sketch.title}</span>
+                                    <span
+                                        class={`block text-xs mt-0.5 ${
+                                            sketch.slug === selectedSketch.slug
+                                                ? "text-gray-200"
+                                                : "text-gray-500"
+                                        }`}
+                                    >
+                                        {formatSketchDate(sketch.date)}
+                                    </span>
+                                </a>
+                            ))}
+                        </nav>
+                    </aside>
+
+                    <div class="flex min-h-0 flex-1 flex-col">
+                        <div class="md:hidden border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+                            <div>
+                                <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketch</p>
+                                <h1 class="text-base font-semibold text-gray-900">{selectedSketch.title}</h1>
+                            </div>
+                            <button
+                                type="button"
+                                data-sketch-menu-toggle
+                                class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                            >
+                                Menu
+                            </button>
+                        </div>
+
+                        <div
+                            data-sketch-menu-panel
+                            class="hidden md:hidden fixed inset-0 z-50 bg-white px-4 pt-20 pb-6 overflow-y-auto"
+                        >
+                            <div class="flex items-center justify-between mb-4">
+                                <h2 class="text-lg font-semibold text-gray-900">Sketches</h2>
+                                <button
+                                    type="button"
+                                    data-sketch-menu-close
+                                    class="rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700"
+                                >
+                                    Close
+                                </button>
+                            </div>
+                            <nav class="space-y-2">
+                                {sketchRegistry.map((sketch) => (
+                                    <a
+                                        data-sketch-menu-link
+                                        href={`/sketches/${sketch.slug}`}
+                                        class={`block rounded-md px-3 py-2 ${
+                                            sketch.slug === selectedSketch.slug
+                                                ? "bg-gray-800 text-white"
+                                                : "bg-gray-100 text-gray-800"
+                                        }`}
+                                    >
+                                        <span class="block text-sm font-semibold">{sketch.title}</span>
+                                        <span
+                                            class={`block text-xs mt-0.5 ${
+                                                sketch.slug === selectedSketch.slug
+                                                    ? "text-gray-200"
+                                                    : "text-gray-500"
+                                            }`}
+                                        >
+                                            {formatSketchDate(sketch.date)}
+                                        </span>
+                                    </a>
+                                ))}
+                            </nav>
+                        </div>
+
+                        <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-3 p-3 md:gap-4 md:p-4">
+                            <section class="rounded-lg border border-gray-200 bg-white p-3 md:p-4">
+                                <div class="flex flex-wrap items-end gap-3 md:gap-4">
+                                    <label class="inline-flex items-center gap-2 text-sm text-gray-800">
+                                        <input
+                                            data-control-reverse
+                                            type="checkbox"
+                                            class="h-4 w-4 rounded border-gray-300 text-gray-800 focus:ring-gray-500"
+                                        />
+                                        Reverse
+                                    </label>
+
+                                    <label class="flex flex-col text-sm text-gray-800">
+                                        <span class="mb-1">Noise seed</span>
+                                        <input
+                                            data-control-noise-seed
+                                            type="number"
+                                            class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
+                                        />
+                                    </label>
+
+                                    <button
+                                        type="button"
+                                        data-control-random-seed
+                                        class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
+                                    >
+                                        Random seed
+                                    </button>
+
+                                    <button
+                                        type="button"
+                                        data-control-reset
+                                        class="rounded border border-gray-800 bg-gray-800 px-3 py-2 text-sm font-medium text-white"
+                                    >
+                                        Reset
+                                    </button>
+                                </div>
+                            </section>
+
+                            <section class="min-h-0 rounded-lg border border-gray-200 bg-white">
+                                <div data-sketch-canvas class="h-full min-h-[340px] w-full"></div>
+                                <p data-sketch-error class="hidden px-4 py-3 text-sm text-red-700"></p>
+                            </section>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        ) : (
+            <section class="max-w-screen-md mx-auto px-4 py-10 md:py-14">
+                <h1 class="text-2xl md:text-4xl font-bold">Sketch not found</h1>
+                <p class="mt-3 text-gray-700">
+                    The sketch you requested does not exist.
+                </p>
+                {latestSketch ? (
+                    <a
+                        href={`/sketches/${latestSketch.slug}`}
+                        class="inline-flex items-center justify-center rounded border border-gray-800 bg-gray-800 px-4 py-2 text-white font-medium mt-6"
+                    >
+                        Go to latest sketch
+                    </a>
+                ) : null}
+            </section>
+        )}
+    </div>
+</BaseLayout>
+
+<script>
+    import { bootSketchesPage } from "@scripts/sketchesPage"
+
+    bootSketchesPage()
+</script>

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -190,6 +190,14 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                                 >
                                     Reset
                                 </button>
+
+                                <button
+                                    type="button"
+                                    data-control-save-image
+                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
+                                >
+                                    Save image
+                                </button>
                             </div>
                         </section>
 

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "@layouts/BaseLayout.astro"
+import SketchLayout from "@layouts/SketchLayout.astro"
 import { getCollection } from "astro:content"
 
 type SketchItem = {
@@ -57,17 +57,17 @@ const pageTitle = `${sketch.title} | Sketches`
 const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription} hideFooter={true} noIndex={true}>
-    <div class="w-full h-[calc(100dvh-80px)]">
+<SketchLayout title={pageTitle} description={pageDescription}>
+    <div class="h-full w-full flex flex-col min-h-0">
         <section
             data-sketch-page-root
             data-sketch-slug={sketch.slug}
             data-default-noise-seed={defaultNoiseSeed}
             data-default-random-seed={defaultRandomSeed}
-            class="max-w-screen-2xl mx-auto h-full"
+            class="flex h-full w-full min-h-0 flex-col"
         >
-            <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
-                <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
+            <div class="grid min-h-0 flex-1 md:grid-cols-[260px_1fr]">
+                <aside class="hidden md:flex md:flex-col md:h-full border-r border-gray-200 bg-gray-50 min-h-0">
                     <div class="border-b border-gray-200 px-4 py-4">
                         <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
                         <p class="text-sm font-medium text-gray-800 mt-1">
@@ -154,8 +154,8 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                         </nav>
                     </div>
 
-                    <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-3 p-3 md:gap-4 md:p-4">
-                        <section class="rounded-lg border border-gray-200 bg-white p-3 md:p-4">
+                    <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-2 p-2">
+                        <section class="shrink-0 border-b border-gray-200 bg-white p-2">
                             <div class="flex flex-wrap items-end gap-3 md:gap-4">
                                 <label class="flex flex-col text-sm text-gray-800">
                                     <span class="mb-1">Noise seed</span>
@@ -201,8 +201,8 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                             </div>
                         </section>
 
-                        <section class="min-h-0 rounded-lg border border-gray-200 bg-white">
-                            <div data-sketch-canvas class="h-full min-h-[340px] w-full"></div>
+                        <section class="min-h-0 flex-1 border border-gray-200 bg-white overflow-hidden">
+                            <div data-sketch-canvas class="h-full w-full min-h-[200px]"></div>
                             <p data-sketch-error class="hidden px-4 py-3 text-sm text-red-700"></p>
                         </section>
                     </div>
@@ -210,7 +210,7 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
             </div>
         </section>
     </div>
-</BaseLayout>
+</SketchLayout>
 
 <script>
     import { bootSketchesPage } from "@scripts/sketchesPage"

--- a/astro/src/pages/sketches/[slug].astro
+++ b/astro/src/pages/sketches/[slug].astro
@@ -73,48 +73,52 @@ const pageDescription = `Interactive p5 sketch: ${sketch.title}.`
                 <div class="flex min-h-0 flex-1 flex-col">
                     <div class="grid min-h-0 flex-1 grid-rows-[auto_1fr] gap-2 p-2">
                         <section class="shrink-0 border-b border-gray-200 bg-white p-2">
-                            <div class="flex flex-wrap items-end gap-3 md:gap-4">
-                                <label class="flex flex-col text-sm text-gray-800">
-                                    <span class="mb-1">Noise seed</span>
-                                    <input
-                                        data-control-noise-seed
-                                        type="number"
-                                        class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
-                                    />
-                                </label>
+                            <div class="flex flex-col gap-2">
+                                <div class="flex items-end gap-3 md:gap-4">
+                                    <label class="flex flex-col text-sm text-gray-800">
+                                        <span class="mb-1">Noise seed</span>
+                                        <input
+                                            data-control-noise-seed
+                                            type="number"
+                                            class="w-24 rounded border border-gray-300 px-2 py-1.5 text-sm"
+                                        />
+                                    </label>
 
-                                <label class="flex flex-col text-sm text-gray-800">
-                                    <span class="mb-1">Random seed</span>
-                                    <input
-                                        data-control-random-seed
-                                        type="number"
-                                        class="w-36 rounded border border-gray-300 px-3 py-2 text-sm"
-                                    />
-                                </label>
+                                    <label class="flex flex-col text-sm text-gray-800">
+                                        <span class="mb-1">Random seed</span>
+                                        <input
+                                            data-control-random-seed
+                                            type="number"
+                                            class="w-24 rounded border border-gray-300 px-2 py-1.5 text-sm"
+                                        />
+                                    </label>
+                                </div>
 
-                                <button
-                                    type="button"
-                                    data-control-randomize-seeds
-                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
-                                >
-                                    Randomise
-                                </button>
+                                <div class="flex items-center gap-3 md:gap-4">
+                                    <button
+                                        type="button"
+                                        data-control-randomize-seeds
+                                        class="text-blue-600 hover:underline text-sm"
+                                    >
+                                        Randomise
+                                    </button>
 
-                                <button
-                                    type="button"
-                                    data-control-reset
-                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
-                                >
-                                    Reset
-                                </button>
+                                    <button
+                                        type="button"
+                                        data-control-reset
+                                        class="text-blue-600 hover:underline text-sm"
+                                    >
+                                        Reset
+                                    </button>
 
-                                <button
-                                    type="button"
-                                    data-control-save-image
-                                    class="rounded border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800"
-                                >
-                                    Save
-                                </button>
+                                    <button
+                                        type="button"
+                                        data-control-save-image
+                                        class="text-blue-600 hover:underline text-sm"
+                                    >
+                                        Save
+                                    </button>
+                                </div>
                             </div>
                         </section>
 

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -1,0 +1,13 @@
+---
+export const prerender = false
+
+import { getLatestSketch } from "../../sketches/registry"
+
+const latestSketch = getLatestSketch()
+
+if (!latestSketch) {
+    throw new Error("No sketches found in registry.")
+}
+
+return Astro.redirect(`/sketches/${latestSketch.slug}`)
+---

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "@layouts/BaseLayout.astro"
+import SketchLayout from "@layouts/SketchLayout.astro"
 import { getCollection } from "astro:content"
 
 type SketchItem = {
@@ -30,11 +30,11 @@ const formatSketchDate = (value: string): string => {
 }
 ---
 
-<BaseLayout title="Sketches" description="Interactive p5.js sketches." hideFooter={true} noIndex={true}>
-    <div class="w-full h-[calc(100dvh-80px)]">
-        <section class="max-w-screen-2xl mx-auto h-full">
-            <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
-                <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
+<SketchLayout title="Sketches" description="Interactive p5.js sketches.">
+    <div class="h-full w-full flex flex-col min-h-0">
+        <section class="flex h-full w-full min-h-0 flex-col">
+            <div class="grid min-h-0 flex-1 md:grid-cols-[260px_1fr]">
+                <aside class="hidden md:flex md:flex-col md:h-full border-r border-gray-200 bg-gray-50 min-h-0">
                     <div class="border-b border-gray-200 px-4 py-4">
                         <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
                         <p class="text-sm font-medium text-gray-800 mt-1">
@@ -56,10 +56,10 @@ const formatSketchDate = (value: string): string => {
                     </nav>
                 </aside>
 
-                <div class="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-gray-500">
+                <div class="flex min-h-0 flex-1 flex-col items-center justify-center p-4 text-gray-500">
                     <p class="text-sm">Choose a sketch from the list.</p>
                 </div>
             </div>
         </section>
     </div>
-</BaseLayout>
+</SketchLayout>

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -1,13 +1,65 @@
 ---
-export const prerender = false
+import BaseLayout from "@layouts/BaseLayout.astro"
+import { getCollection } from "astro:content"
 
-import { getLatestSketch } from "../../sketches/registry"
-
-const latestSketch = getLatestSketch()
-
-if (!latestSketch) {
-    throw new Error("No sketches found in registry.")
+type SketchItem = {
+    slug: string
+    title: string
+    date: string
 }
 
-return Astro.redirect(`/sketches/${latestSketch.slug}`)
+const entries = await getCollection("sketches")
+const allSketches: SketchItem[] = [...entries]
+    .sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date))
+    .map(entry => ({
+        slug: entry.id,
+        title: entry.data.title,
+        date: entry.data.date,
+    }))
+
+const dateFormatter = new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+})
+
+const formatSketchDate = (value: string): string => {
+    const parsedDate = Date.parse(value)
+    if (Number.isNaN(parsedDate)) return value
+    return dateFormatter.format(new Date(parsedDate))
+}
 ---
+
+<BaseLayout title="Sketches" description="Interactive p5.js sketches." hideFooter={true} noIndex={true}>
+    <div class="w-full h-[calc(100dvh-80px)]">
+        <section class="max-w-screen-2xl mx-auto h-full">
+            <div class="h-full min-h-0 grid md:grid-cols-[260px_1fr]">
+                <aside class="hidden md:flex md:flex-col border-r border-gray-200 bg-gray-50 min-h-0">
+                    <div class="border-b border-gray-200 px-4 py-4">
+                        <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
+                        <p class="text-sm font-medium text-gray-800 mt-1">
+                            {allSketches.length} total
+                        </p>
+                    </div>
+                    <nav class="flex-1 min-h-0 overflow-y-auto p-2">
+                        {allSketches.map((s) => (
+                            <a
+                                href={`/sketches/${s.slug}`}
+                                class="block rounded-md px-3 py-2 mb-2 transition-colors duration-200 text-gray-700 md:hover:bg-gray-200"
+                            >
+                                <span class="block text-sm font-semibold">{s.title}</span>
+                                <span class="block text-xs mt-0.5 text-gray-500">
+                                    {formatSketchDate(s.date)}
+                                </span>
+                            </a>
+                        ))}
+                    </nav>
+                </aside>
+
+                <div class="flex min-h-0 flex-1 flex-col items-center justify-center p-6 text-gray-500">
+                    <p class="text-sm">Choose a sketch from the list.</p>
+                </div>
+            </div>
+        </section>
+    </div>
+</BaseLayout>

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -17,40 +17,20 @@ const allSketches: SketchItem[] = [...entries]
         date: entry.data.date,
     }))
 
-const dateFormatter = new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-})
-
-const formatSketchDate = (value: string): string => {
-    const parsedDate = Date.parse(value)
-    if (Number.isNaN(parsedDate)) return value
-    return dateFormatter.format(new Date(parsedDate))
-}
 ---
 
 <SketchLayout title="Sketches" description="Interactive p5.js sketches.">
     <div class="h-full w-full flex flex-col min-h-0">
-        <section class="flex h-full w-full min-h-0 flex-col">
-            <div class="grid min-h-0 flex-1 md:grid-cols-[260px_1fr]">
-                <aside class="hidden md:flex md:flex-col md:h-full border-r border-gray-200 bg-gray-50 min-h-0">
-                    <div class="border-b border-gray-200 px-4 py-4">
-                        <p class="text-xs uppercase tracking-[0.15em] text-gray-500">Sketches</p>
-                        <p class="text-sm font-medium text-gray-800 mt-1">
-                            {allSketches.length} total
-                        </p>
-                    </div>
+        <section data-sketch-page-root class="flex h-full w-full min-h-0 flex-col">
+            <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
+                <aside class="flex min-w-0 flex-col h-full min-h-0 border-r border-gray-200 bg-gray-50">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a
                                 href={`/sketches/${s.slug}`}
-                                class="block rounded-md px-3 py-2 mb-2 transition-colors duration-200 text-gray-700 md:hover:bg-gray-200"
+                                class="block min-w-0 py-1 mb-0.5 text-blue-600 hover:underline"
                             >
-                                <span class="block text-sm font-semibold">{s.title}</span>
-                                <span class="block text-xs mt-0.5 text-gray-500">
-                                    {formatSketchDate(s.date)}
-                                </span>
+                                <span class="block break-words text-sm">{s.title}</span>
                             </a>
                         ))}
                     </nav>
@@ -63,3 +43,9 @@ const formatSketchDate = (value: string): string => {
         </section>
     </div>
 </SketchLayout>
+
+<script>
+    import { bootSketchesPage } from "@scripts/sketchesPage"
+
+    bootSketchesPage()
+</script>

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -23,7 +23,7 @@ const allSketches: SketchItem[] = [...entries]
     <div class="h-full w-full flex flex-col min-h-0">
         <section data-sketch-page-root class="flex h-full w-full min-h-0 flex-col">
             <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
-                <aside class="flex min-w-0 flex-col h-full min-h-0 bg-gray-50">
+                <aside class="flex min-w-0 flex-col h-full min-h-0">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a

--- a/astro/src/pages/sketches/index.astro
+++ b/astro/src/pages/sketches/index.astro
@@ -23,7 +23,7 @@ const allSketches: SketchItem[] = [...entries]
     <div class="h-full w-full flex flex-col min-h-0">
         <section data-sketch-page-root class="flex h-full w-full min-h-0 flex-col">
             <div class="grid min-h-0 flex-1 grid-cols-[100px_1fr] md:grid-cols-[120px_1fr]">
-                <aside class="flex min-w-0 flex-col h-full min-h-0 border-r border-gray-200 bg-gray-50">
+                <aside class="flex min-w-0 flex-col h-full min-h-0 bg-gray-50">
                     <nav class="flex-1 min-h-0 overflow-y-auto p-2">
                         {allSketches.map((s) => (
                             <a

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -1,6 +1,6 @@
 import p5 from "p5"
-import { getDefaultControlsForSketch, loadSketchModule } from "../sketches/registry"
-import { mergeSketchControls, type SketchControls } from "../sketches/types"
+import { loadSketchModule } from "../sketches/registry"
+import { DEFAULT_SKETCH_CONTROLS, mergeSketchControls, type SketchControls } from "../sketches/types"
 
 type CleanupFn = () => void
 
@@ -105,7 +105,13 @@ const initialiseSketchPage = async (): Promise<void> => {
         return
     }
 
-    const defaultControls = getDefaultControlsForSketch(sketchSlug)
+    const defaultControls: SketchControls = mergeSketchControls(
+        {
+            noiseSeed: parseSeed(root.dataset.defaultNoiseSeed ?? null, DEFAULT_SKETCH_CONTROLS.noiseSeed),
+            randomSeed: parseSeed(root.dataset.defaultRandomSeed ?? null, DEFAULT_SKETCH_CONTROLS.randomSeed),
+        },
+        DEFAULT_SKETCH_CONTROLS,
+    )
     const searchParams = new URLSearchParams(window.location.search)
 
     let controls = hasControlParams(searchParams)

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -50,36 +50,6 @@ const writeControlsToUrl = (controls: SketchControls) => {
     window.history.replaceState(window.history.state, "", nextUrl)
 }
 
-const initialiseMobileMenu = (root: HTMLElement): CleanupFn => {
-    const menuPanel = root.querySelector<HTMLElement>("[data-sketch-menu-panel]")
-    const menuToggle = root.querySelector<HTMLButtonElement>("[data-sketch-menu-toggle]")
-    const menuClose = root.querySelector<HTMLButtonElement>("[data-sketch-menu-close]")
-    const menuLinks = root.querySelectorAll<HTMLAnchorElement>("[data-sketch-menu-link]")
-
-    if (!menuPanel || !menuToggle || !menuClose) return () => {}
-
-    const closeMenu = () => {
-        menuPanel.classList.add("hidden")
-        document.body.style.overflow = ""
-    }
-
-    const openMenu = () => {
-        menuPanel.classList.remove("hidden")
-        document.body.style.overflow = "hidden"
-    }
-
-    menuToggle.addEventListener("click", openMenu)
-    menuClose.addEventListener("click", closeMenu)
-    menuLinks.forEach(link => link.addEventListener("click", closeMenu))
-
-    return () => {
-        closeMenu()
-        menuToggle.removeEventListener("click", openMenu)
-        menuClose.removeEventListener("click", closeMenu)
-        menuLinks.forEach(link => link.removeEventListener("click", closeMenu))
-    }
-}
-
 const initialiseSketchPage = async (): Promise<void> => {
     const runtimeWindow = window as SketchesWindow
 
@@ -193,7 +163,6 @@ const initialiseSketchPage = async (): Promise<void> => {
     cleanupFunctions.push(() => randomizeButton.removeEventListener("click", handleRandomizeSeeds))
     cleanupFunctions.push(() => resetButton.removeEventListener("click", handleReset))
     cleanupFunctions.push(() => saveImageButton.removeEventListener("click", handleSaveImage))
-    cleanupFunctions.push(initialiseMobileMenu(root))
 
     runtimeWindow.__sketchesPageCleanup = () => {
         if (disposed) return

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -10,13 +10,12 @@ type SketchesWindow = Window & {
 }
 
 const ROOT_SELECTOR = "[data-sketch-page-root]"
-const SKETCH_QUERY_KEYS = ["noiseSeed"]
+const SKETCH_QUERY_KEYS = ["noiseSeed", "randomSeed"]
 
-const parseNoiseSeed = (value: string | null, fallback: number): number => {
+const parseSeed = (value: string | null, fallback: number): number => {
     if (value === null) return fallback
-
-    const parsedSeed = Number.parseInt(value, 10)
-    return Number.isNaN(parsedSeed) ? fallback : parsedSeed
+    const parsed = Number.parseInt(value, 10)
+    return Number.isNaN(parsed) ? fallback : parsed
 }
 
 const hasControlParams = (searchParams: URLSearchParams): boolean =>
@@ -45,6 +44,7 @@ const removeControlParamsFromUrl = () => {
 const writeControlsToUrl = (controls: SketchControls) => {
     const searchParams = new URLSearchParams(window.location.search)
     searchParams.set("noiseSeed", `${controls.noiseSeed}`)
+    searchParams.set("randomSeed", `${controls.randomSeed}`)
 
     const nextUrl = `${window.location.pathname}?${searchParams.toString()}${window.location.hash}`
     window.history.replaceState(window.history.state, "", nextUrl)
@@ -97,10 +97,11 @@ const initialiseSketchPage = async (): Promise<void> => {
     const canvasContainer = root.querySelector<HTMLElement>("[data-sketch-canvas]")
     const errorMessage = root.querySelector<HTMLElement>("[data-sketch-error]")
     const noiseSeedInput = root.querySelector<HTMLInputElement>("[data-control-noise-seed]")
-    const randomSeedButton = root.querySelector<HTMLButtonElement>("[data-control-random-seed]")
+    const randomSeedInput = root.querySelector<HTMLInputElement>("[data-control-random-seed]")
+    const randomizeButton = root.querySelector<HTMLButtonElement>("[data-control-randomize-seeds]")
     const resetButton = root.querySelector<HTMLButtonElement>("[data-control-reset]")
 
-    if (!canvasContainer || !noiseSeedInput || !randomSeedButton || !resetButton) {
+    if (!canvasContainer || !noiseSeedInput || !randomSeedInput || !randomizeButton || !resetButton) {
         return
     }
 
@@ -110,13 +111,15 @@ const initialiseSketchPage = async (): Promise<void> => {
     let controls = hasControlParams(searchParams)
         ? mergeSketchControls(
               {
-                  noiseSeed: parseNoiseSeed(searchParams.get("noiseSeed"), defaultControls.noiseSeed),
+                  noiseSeed: parseSeed(searchParams.get("noiseSeed"), defaultControls.noiseSeed),
+                  randomSeed: parseSeed(searchParams.get("randomSeed"), defaultControls.randomSeed),
               },
               defaultControls,
           )
         : defaultControls
 
     noiseSeedInput.value = `${controls.noiseSeed}`
+    randomSeedInput.value = `${controls.randomSeed}`
     if (errorMessage) errorMessage.classList.add("hidden")
 
     let sketchInstance: p5 | null = null
@@ -126,12 +129,14 @@ const initialiseSketchPage = async (): Promise<void> => {
     const syncControlsFromInputs = () => {
         controls = mergeSketchControls(
             {
-                noiseSeed: parseNoiseSeed(noiseSeedInput.value, controls.noiseSeed),
+                noiseSeed: parseSeed(noiseSeedInput.value, controls.noiseSeed),
+                randomSeed: parseSeed(randomSeedInput.value, controls.randomSeed),
             },
             defaultControls,
         )
 
         noiseSeedInput.value = `${controls.noiseSeed}`
+        randomSeedInput.value = `${controls.randomSeed}`
     }
 
     const handleNoiseSeedChange = () => {
@@ -139,25 +144,39 @@ const initialiseSketchPage = async (): Promise<void> => {
         writeControlsToUrl(controls)
     }
 
-    const handleRandomSeed = () => {
-        const randomSeed = Math.floor(Math.random() * 1_000_000)
-        controls = mergeSketchControls({ noiseSeed: randomSeed }, defaultControls)
+    const handleRandomSeedChange = () => {
+        syncControlsFromInputs()
+        writeControlsToUrl(controls)
+    }
+
+    const handleRandomizeSeeds = () => {
+        controls = mergeSketchControls(
+            {
+                noiseSeed: Math.floor(Math.random() * 1_000_000),
+                randomSeed: Math.floor(Math.random() * 1_000_000),
+            },
+            defaultControls,
+        )
         noiseSeedInput.value = `${controls.noiseSeed}`
+        randomSeedInput.value = `${controls.randomSeed}`
         writeControlsToUrl(controls)
     }
 
     const handleReset = () => {
         controls = defaultControls
         noiseSeedInput.value = `${controls.noiseSeed}`
+        randomSeedInput.value = `${controls.randomSeed}`
         removeControlParamsFromUrl()
     }
 
     noiseSeedInput.addEventListener("change", handleNoiseSeedChange)
-    randomSeedButton.addEventListener("click", handleRandomSeed)
+    randomSeedInput.addEventListener("change", handleRandomSeedChange)
+    randomizeButton.addEventListener("click", handleRandomizeSeeds)
     resetButton.addEventListener("click", handleReset)
 
     cleanupFunctions.push(() => noiseSeedInput.removeEventListener("change", handleNoiseSeedChange))
-    cleanupFunctions.push(() => randomSeedButton.removeEventListener("click", handleRandomSeed))
+    cleanupFunctions.push(() => randomSeedInput.removeEventListener("change", handleRandomSeedChange))
+    cleanupFunctions.push(() => randomizeButton.removeEventListener("click", handleRandomizeSeeds))
     cleanupFunctions.push(() => resetButton.removeEventListener("click", handleReset))
     cleanupFunctions.push(initialiseMobileMenu(root))
 

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -100,8 +100,9 @@ const initialiseSketchPage = async (): Promise<void> => {
     const randomSeedInput = root.querySelector<HTMLInputElement>("[data-control-random-seed]")
     const randomizeButton = root.querySelector<HTMLButtonElement>("[data-control-randomize-seeds]")
     const resetButton = root.querySelector<HTMLButtonElement>("[data-control-reset]")
+    const saveImageButton = root.querySelector<HTMLButtonElement>("[data-control-save-image]")
 
-    if (!canvasContainer || !noiseSeedInput || !randomSeedInput || !randomizeButton || !resetButton) {
+    if (!canvasContainer || !noiseSeedInput || !randomSeedInput || !randomizeButton || !resetButton || !saveImageButton) {
         return
     }
 
@@ -175,15 +176,23 @@ const initialiseSketchPage = async (): Promise<void> => {
         removeControlParamsFromUrl()
     }
 
+    const handleSaveImage = () => {
+        if (sketchInstance) {
+            sketchInstance.saveCanvas(sketchSlug, "png")
+        }
+    }
+
     noiseSeedInput.addEventListener("change", handleNoiseSeedChange)
     randomSeedInput.addEventListener("change", handleRandomSeedChange)
     randomizeButton.addEventListener("click", handleRandomizeSeeds)
     resetButton.addEventListener("click", handleReset)
+    saveImageButton.addEventListener("click", handleSaveImage)
 
     cleanupFunctions.push(() => noiseSeedInput.removeEventListener("change", handleNoiseSeedChange))
     cleanupFunctions.push(() => randomSeedInput.removeEventListener("change", handleRandomSeedChange))
     cleanupFunctions.push(() => randomizeButton.removeEventListener("click", handleRandomizeSeeds))
     cleanupFunctions.push(() => resetButton.removeEventListener("click", handleReset))
+    cleanupFunctions.push(() => saveImageButton.removeEventListener("click", handleSaveImage))
     cleanupFunctions.push(initialiseMobileMenu(root))
 
     runtimeWindow.__sketchesPageCleanup = () => {

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -1,0 +1,249 @@
+import p5 from "p5"
+import { getDefaultControlsForSketch, loadSketchModule } from "../sketches/registry"
+import { mergeSketchControls, type SketchControls } from "../sketches/types"
+
+type CleanupFn = () => void
+
+type SketchesWindow = Window & {
+    __sketchesPageBootstrapped?: boolean
+    __sketchesPageCleanup?: CleanupFn
+}
+
+const ROOT_SELECTOR = "[data-sketch-page-root]"
+const SKETCH_QUERY_KEYS = ["reverse", "noiseSeed"]
+
+const parseBoolean = (value: string | null, fallback: boolean): boolean => {
+    if (value === null) return fallback
+    const normalisedValue = value.trim().toLowerCase()
+
+    if (normalisedValue === "1" || normalisedValue === "true" || normalisedValue === "yes") {
+        return true
+    }
+
+    if (normalisedValue === "0" || normalisedValue === "false" || normalisedValue === "no") {
+        return false
+    }
+
+    return fallback
+}
+
+const parseNoiseSeed = (value: string | null, fallback: number): number => {
+    if (value === null) return fallback
+
+    const parsedSeed = Number.parseInt(value, 10)
+    return Number.isNaN(parsedSeed) ? fallback : parsedSeed
+}
+
+const hasControlParams = (searchParams: URLSearchParams): boolean =>
+    SKETCH_QUERY_KEYS.some(key => searchParams.has(key))
+
+const removeControlParamsFromUrl = () => {
+    const searchParams = new URLSearchParams(window.location.search)
+    let urlChanged = false
+
+    for (const key of SKETCH_QUERY_KEYS) {
+        if (!searchParams.has(key)) continue
+        searchParams.delete(key)
+        urlChanged = true
+    }
+
+    if (!urlChanged) return
+
+    const nextQuery = searchParams.toString()
+    const nextUrl = nextQuery
+        ? `${window.location.pathname}?${nextQuery}${window.location.hash}`
+        : `${window.location.pathname}${window.location.hash}`
+
+    window.history.replaceState(window.history.state, "", nextUrl)
+}
+
+const writeControlsToUrl = (controls: SketchControls) => {
+    const searchParams = new URLSearchParams(window.location.search)
+    searchParams.set("reverse", controls.reverse ? "1" : "0")
+    searchParams.set("noiseSeed", `${controls.noiseSeed}`)
+
+    const nextUrl = `${window.location.pathname}?${searchParams.toString()}${window.location.hash}`
+    window.history.replaceState(window.history.state, "", nextUrl)
+}
+
+const initialiseMobileMenu = (root: HTMLElement): CleanupFn => {
+    const menuPanel = root.querySelector<HTMLElement>("[data-sketch-menu-panel]")
+    const menuToggle = root.querySelector<HTMLButtonElement>("[data-sketch-menu-toggle]")
+    const menuClose = root.querySelector<HTMLButtonElement>("[data-sketch-menu-close]")
+    const menuLinks = root.querySelectorAll<HTMLAnchorElement>("[data-sketch-menu-link]")
+
+    if (!menuPanel || !menuToggle || !menuClose) return () => {}
+
+    const closeMenu = () => {
+        menuPanel.classList.add("hidden")
+        document.body.style.overflow = ""
+    }
+
+    const openMenu = () => {
+        menuPanel.classList.remove("hidden")
+        document.body.style.overflow = "hidden"
+    }
+
+    menuToggle.addEventListener("click", openMenu)
+    menuClose.addEventListener("click", closeMenu)
+    menuLinks.forEach(link => link.addEventListener("click", closeMenu))
+
+    return () => {
+        closeMenu()
+        menuToggle.removeEventListener("click", openMenu)
+        menuClose.removeEventListener("click", closeMenu)
+        menuLinks.forEach(link => link.removeEventListener("click", closeMenu))
+    }
+}
+
+const initialiseSketchPage = async (): Promise<void> => {
+    const runtimeWindow = window as SketchesWindow
+
+    if (runtimeWindow.__sketchesPageCleanup) {
+        runtimeWindow.__sketchesPageCleanup()
+        runtimeWindow.__sketchesPageCleanup = undefined
+    }
+
+    const root = document.querySelector<HTMLElement>(ROOT_SELECTOR)
+    if (!root) return
+
+    const sketchSlug = root.dataset.sketchSlug
+    if (!sketchSlug) return
+
+    const canvasContainer = root.querySelector<HTMLElement>("[data-sketch-canvas]")
+    const errorMessage = root.querySelector<HTMLElement>("[data-sketch-error]")
+    const reverseInput = root.querySelector<HTMLInputElement>("[data-control-reverse]")
+    const noiseSeedInput = root.querySelector<HTMLInputElement>("[data-control-noise-seed]")
+    const randomSeedButton = root.querySelector<HTMLButtonElement>("[data-control-random-seed]")
+    const resetButton = root.querySelector<HTMLButtonElement>("[data-control-reset]")
+
+    if (!canvasContainer || !reverseInput || !noiseSeedInput || !randomSeedButton || !resetButton) {
+        return
+    }
+
+    const defaultControls = getDefaultControlsForSketch(sketchSlug)
+    const searchParams = new URLSearchParams(window.location.search)
+
+    let controls = hasControlParams(searchParams)
+        ? mergeSketchControls(
+              {
+                  reverse: parseBoolean(searchParams.get("reverse"), defaultControls.reverse),
+                  noiseSeed: parseNoiseSeed(searchParams.get("noiseSeed"), defaultControls.noiseSeed),
+              },
+              defaultControls,
+          )
+        : defaultControls
+
+    reverseInput.checked = controls.reverse
+    noiseSeedInput.value = `${controls.noiseSeed}`
+    if (errorMessage) errorMessage.classList.add("hidden")
+
+    let sketchInstance: p5 | null = null
+    let disposed = false
+    const cleanupFunctions: CleanupFn[] = []
+
+    const syncControlsFromInputs = () => {
+        controls = mergeSketchControls(
+            {
+                reverse: reverseInput.checked,
+                noiseSeed: parseNoiseSeed(noiseSeedInput.value, controls.noiseSeed),
+            },
+            defaultControls,
+        )
+
+        reverseInput.checked = controls.reverse
+        noiseSeedInput.value = `${controls.noiseSeed}`
+    }
+
+    const handleReverseChange = () => {
+        syncControlsFromInputs()
+        writeControlsToUrl(controls)
+    }
+
+    const handleNoiseSeedChange = () => {
+        syncControlsFromInputs()
+        writeControlsToUrl(controls)
+    }
+
+    const handleRandomSeed = () => {
+        const randomSeed = Math.floor(Math.random() * 1_000_000)
+        controls = mergeSketchControls({ reverse: reverseInput.checked, noiseSeed: randomSeed }, defaultControls)
+        reverseInput.checked = controls.reverse
+        noiseSeedInput.value = `${controls.noiseSeed}`
+        writeControlsToUrl(controls)
+    }
+
+    const handleReset = () => {
+        controls = defaultControls
+        reverseInput.checked = controls.reverse
+        noiseSeedInput.value = `${controls.noiseSeed}`
+        removeControlParamsFromUrl()
+    }
+
+    reverseInput.addEventListener("change", handleReverseChange)
+    noiseSeedInput.addEventListener("change", handleNoiseSeedChange)
+    randomSeedButton.addEventListener("click", handleRandomSeed)
+    resetButton.addEventListener("click", handleReset)
+
+    cleanupFunctions.push(() => reverseInput.removeEventListener("change", handleReverseChange))
+    cleanupFunctions.push(() => noiseSeedInput.removeEventListener("change", handleNoiseSeedChange))
+    cleanupFunctions.push(() => randomSeedButton.removeEventListener("click", handleRandomSeed))
+    cleanupFunctions.push(() => resetButton.removeEventListener("click", handleReset))
+    cleanupFunctions.push(initialiseMobileMenu(root))
+
+    runtimeWindow.__sketchesPageCleanup = () => {
+        if (disposed) return
+        disposed = true
+
+        cleanupFunctions.forEach(cleanup => cleanup())
+        cleanupFunctions.length = 0
+
+        if (sketchInstance) {
+            sketchInstance.remove()
+            sketchInstance = null
+        }
+    }
+
+    try {
+        const sketchModule = await loadSketchModule(sketchSlug)
+        if (disposed) return
+
+        if (!sketchModule) {
+            if (errorMessage) {
+                errorMessage.textContent = "Unable to load this sketch."
+                errorMessage.classList.remove("hidden")
+            }
+            return
+        }
+
+        sketchInstance = new p5((instance) => sketchModule.default(instance, () => controls), canvasContainer)
+    } catch (error) {
+        if (disposed) return
+
+        if (errorMessage) {
+            errorMessage.textContent = "Unable to load this sketch."
+            errorMessage.classList.remove("hidden")
+        }
+    }
+}
+
+export const bootSketchesPage = () => {
+    const runtimeWindow = window as SketchesWindow
+
+    if (runtimeWindow.__sketchesPageBootstrapped) {
+        void initialiseSketchPage()
+        return
+    }
+
+    runtimeWindow.__sketchesPageBootstrapped = true
+    document.addEventListener("astro:before-swap", () => {
+        if (!runtimeWindow.__sketchesPageCleanup) return
+        runtimeWindow.__sketchesPageCleanup()
+        runtimeWindow.__sketchesPageCleanup = undefined
+    })
+    document.addEventListener("astro:page-load", () => {
+        void initialiseSketchPage()
+    })
+
+    void initialiseSketchPage()
+}

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -147,9 +147,14 @@ const initialiseSketchPage = async (): Promise<void> => {
     }
 
     const handleSaveImage = () => {
-        if (sketchInstance) {
-            sketchInstance.saveCanvas(sketchSlug, "png")
-        }
+        if (!sketchInstance) return
+        const canvas = canvasContainer.querySelector("canvas")
+        if (!canvas) return
+        const filename = `${sketchSlug}_noise${controls.noiseSeed}_random${controls.randomSeed}_w${sketchInstance.width}_h${sketchInstance.height}.png`
+        const link = document.createElement("a")
+        link.download = filename
+        link.href = canvas.toDataURL("image/png")
+        link.click()
     }
 
     noiseSeedInput.addEventListener("change", handleNoiseSeedChange)

--- a/astro/src/scripts/sketchesPage.ts
+++ b/astro/src/scripts/sketchesPage.ts
@@ -10,22 +10,7 @@ type SketchesWindow = Window & {
 }
 
 const ROOT_SELECTOR = "[data-sketch-page-root]"
-const SKETCH_QUERY_KEYS = ["reverse", "noiseSeed"]
-
-const parseBoolean = (value: string | null, fallback: boolean): boolean => {
-    if (value === null) return fallback
-    const normalisedValue = value.trim().toLowerCase()
-
-    if (normalisedValue === "1" || normalisedValue === "true" || normalisedValue === "yes") {
-        return true
-    }
-
-    if (normalisedValue === "0" || normalisedValue === "false" || normalisedValue === "no") {
-        return false
-    }
-
-    return fallback
-}
+const SKETCH_QUERY_KEYS = ["noiseSeed"]
 
 const parseNoiseSeed = (value: string | null, fallback: number): number => {
     if (value === null) return fallback
@@ -59,7 +44,6 @@ const removeControlParamsFromUrl = () => {
 
 const writeControlsToUrl = (controls: SketchControls) => {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set("reverse", controls.reverse ? "1" : "0")
     searchParams.set("noiseSeed", `${controls.noiseSeed}`)
 
     const nextUrl = `${window.location.pathname}?${searchParams.toString()}${window.location.hash}`
@@ -112,12 +96,11 @@ const initialiseSketchPage = async (): Promise<void> => {
 
     const canvasContainer = root.querySelector<HTMLElement>("[data-sketch-canvas]")
     const errorMessage = root.querySelector<HTMLElement>("[data-sketch-error]")
-    const reverseInput = root.querySelector<HTMLInputElement>("[data-control-reverse]")
     const noiseSeedInput = root.querySelector<HTMLInputElement>("[data-control-noise-seed]")
     const randomSeedButton = root.querySelector<HTMLButtonElement>("[data-control-random-seed]")
     const resetButton = root.querySelector<HTMLButtonElement>("[data-control-reset]")
 
-    if (!canvasContainer || !reverseInput || !noiseSeedInput || !randomSeedButton || !resetButton) {
+    if (!canvasContainer || !noiseSeedInput || !randomSeedButton || !resetButton) {
         return
     }
 
@@ -127,14 +110,12 @@ const initialiseSketchPage = async (): Promise<void> => {
     let controls = hasControlParams(searchParams)
         ? mergeSketchControls(
               {
-                  reverse: parseBoolean(searchParams.get("reverse"), defaultControls.reverse),
                   noiseSeed: parseNoiseSeed(searchParams.get("noiseSeed"), defaultControls.noiseSeed),
               },
               defaultControls,
           )
         : defaultControls
 
-    reverseInput.checked = controls.reverse
     noiseSeedInput.value = `${controls.noiseSeed}`
     if (errorMessage) errorMessage.classList.add("hidden")
 
@@ -145,19 +126,12 @@ const initialiseSketchPage = async (): Promise<void> => {
     const syncControlsFromInputs = () => {
         controls = mergeSketchControls(
             {
-                reverse: reverseInput.checked,
                 noiseSeed: parseNoiseSeed(noiseSeedInput.value, controls.noiseSeed),
             },
             defaultControls,
         )
 
-        reverseInput.checked = controls.reverse
         noiseSeedInput.value = `${controls.noiseSeed}`
-    }
-
-    const handleReverseChange = () => {
-        syncControlsFromInputs()
-        writeControlsToUrl(controls)
     }
 
     const handleNoiseSeedChange = () => {
@@ -167,25 +141,21 @@ const initialiseSketchPage = async (): Promise<void> => {
 
     const handleRandomSeed = () => {
         const randomSeed = Math.floor(Math.random() * 1_000_000)
-        controls = mergeSketchControls({ reverse: reverseInput.checked, noiseSeed: randomSeed }, defaultControls)
-        reverseInput.checked = controls.reverse
+        controls = mergeSketchControls({ noiseSeed: randomSeed }, defaultControls)
         noiseSeedInput.value = `${controls.noiseSeed}`
         writeControlsToUrl(controls)
     }
 
     const handleReset = () => {
         controls = defaultControls
-        reverseInput.checked = controls.reverse
         noiseSeedInput.value = `${controls.noiseSeed}`
         removeControlParamsFromUrl()
     }
 
-    reverseInput.addEventListener("change", handleReverseChange)
     noiseSeedInput.addEventListener("change", handleNoiseSeedChange)
     randomSeedButton.addEventListener("click", handleRandomSeed)
     resetButton.addEventListener("click", handleReset)
 
-    cleanupFunctions.push(() => reverseInput.removeEventListener("change", handleReverseChange))
     cleanupFunctions.push(() => noiseSeedInput.removeEventListener("change", handleNoiseSeedChange))
     cleanupFunctions.push(() => randomSeedButton.removeEventListener("click", handleRandomSeed))
     cleanupFunctions.push(() => resetButton.removeEventListener("click", handleReset))

--- a/astro/src/sketches/definitions/coneLines.ts
+++ b/astro/src/sketches/definitions/coneLines.ts
@@ -1,0 +1,200 @@
+import type p5 from "p5"
+import { createSketch } from "../sketchCommon"
+
+type HSB = [number, number, number, number]
+
+interface Segment {
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+    r1: number
+    r2: number
+    colourStart: HSB
+    colourEnd: HSB
+}
+
+/** HSB colour palette [hue, saturation, brightness, alpha] */
+const COLOUR_PALETTE: HSB[] = [
+    [22, 72, 92, 0.9],
+    [340, 45, 95, 0.9],
+    [185, 55, 88, 0.9],
+    [45, 70, 95, 0.9],
+    [270, 35, 90, 0.9],
+    [160, 50, 85, 0.9],
+    [12, 80, 88, 0.9],
+    [200, 60, 75, 0.9],
+]
+
+const NUM_SEGMENTS = 8
+const MIN_RADIUS = 10
+const MAX_RADIUS = 58
+/** Gaussian mean/sd for radius (clamped to min/max) – smaller so elements don’t fully overlap */
+const RADIUS_MEAN = 30
+const RADIUS_SD = 14
+/** Gaussian mean/sd for ratio of end radii (clamped); >1 = end often bigger, spread = more variety */
+const RATIO_MEAN = 1.1
+const RATIO_SD = 0.7
+const MIN_RATIO = 0.25
+const MAX_RATIO = 4.5
+
+/** Convert HSB [h 0–360, s 0–100, b 0–100, a 0–1] to CSS rgba() string */
+function hsbToRgba([h, s, b, a]: HSB): string {
+    s /= 100
+    b /= 100
+    const c = b * s
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+    const m = b - c
+    let r = 0,
+        g = 0,
+        bl = 0
+    if (h < 60) {
+        r = c
+        g = x
+    } else if (h < 120) {
+        r = x
+        g = c
+    } else if (h < 180) {
+        g = c
+        bl = x
+    } else if (h < 240) {
+        g = x
+        bl = c
+    } else if (h < 300) {
+        r = x
+        bl = c
+    } else {
+        r = c
+        bl = x
+    }
+    const R = Math.round((r + m) * 255)
+    const G = Math.round((g + m) * 255)
+    const B = Math.round((bl + m) * 255)
+    return `rgba(${R},${G},${B},${a})`
+}
+
+function drawCone(
+    scope: p5,
+    x1: number,
+    y1: number,
+    r1: number,
+    x2: number,
+    y2: number,
+    r2: number,
+    colourStart: HSB,
+    colourEnd: HSB,
+) {
+    const { fill, noStroke, beginShape, endShape, vertex, ellipse, color } = scope
+    noStroke()
+
+    const dx = x2 - x1
+    const dy = y2 - y1
+    const len = Math.hypot(dx, dy) || 1
+    const nx = -dy / len
+    const ny = dx / len
+
+    const p1x = x1 + r1 * nx
+    const p1y = y1 + r1 * ny
+    const p2x = x1 - r1 * nx
+    const p2y = y1 - r1 * ny
+    const p3x = x2 - r2 * nx
+    const p3y = y2 - r2 * ny
+    const p4x = x2 + r2 * nx
+    const p4y = y2 + r2 * ny
+
+    const c1 = color(...colourStart)
+    const c2 = color(...colourEnd)
+
+    const renderer = (scope as unknown as { _renderer?: { drawingContext: CanvasRenderingContext2D } })._renderer
+    const ctx = renderer?.drawingContext
+    if (ctx) {
+        const startStyle = hsbToRgba(colourStart)
+        const endStyle = hsbToRgba(colourEnd)
+        const grad = ctx.createLinearGradient(x1, y1, x2, y2)
+        grad.addColorStop(0, startStyle)
+        grad.addColorStop(1, endStyle)
+        ctx.fillStyle = grad
+        ctx.beginPath()
+        ctx.moveTo(p1x, p1y)
+        ctx.lineTo(p4x, p4y)
+        ctx.lineTo(p3x, p3y)
+        ctx.lineTo(p2x, p2y)
+        ctx.closePath()
+        ctx.fill()
+    } else {
+        fill(c1)
+        beginShape()
+        vertex(p1x, p1y)
+        vertex(p4x, p4y)
+        vertex(p3x, p3y)
+        vertex(p2x, p2y)
+        endShape(scope.CLOSE)
+    }
+
+    fill(c1)
+    ellipse(x1, y1, r1 * 2, r1 * 2)
+    fill(c2)
+    ellipse(x2, y2, r2 * 2, r2 * 2)
+}
+
+let segments: Segment[] | null = null
+let lastRandomSeed = -1
+
+export default createSketch({
+    setup() {},
+    draw(scope, getControls) {
+        const { background, width, height, random, randomSeed } = scope
+        const seed = getControls().randomSeed
+        if (seed !== lastRandomSeed) {
+            lastRandomSeed = seed
+            segments = null
+        }
+
+        if (!segments) {
+            randomSeed(seed)
+            segments = []
+            const { randomGaussian, constrain } = scope
+            for (let i = 0; i < NUM_SEGMENTS; i++) {
+                const palette = COLOUR_PALETTE
+                const idx = () => Math.floor(random(palette.length))
+                const r1 = constrain(
+                    randomGaussian(RADIUS_MEAN, RADIUS_SD),
+                    MIN_RADIUS,
+                    MAX_RADIUS,
+                )
+                const ratio = constrain(
+                    randomGaussian(RATIO_MEAN, RATIO_SD),
+                    MIN_RATIO,
+                    MAX_RATIO,
+                )
+                const r2 = constrain(r1 * ratio, MIN_RADIUS, MAX_RADIUS)
+            segments.push({
+                    x1: random(width * 0.1, width * 0.9),
+                    y1: random(height * 0.1, height * 0.9),
+                    x2: random(width * 0.1, width * 0.9),
+                    y2: random(height * 0.1, height * 0.9),
+                    r1,
+                    r2,
+                    colourStart: palette[idx()],
+                    colourEnd: palette[idx()],
+                })
+            }
+        }
+
+        background(30, 8, 98)
+
+        for (const seg of segments) {
+            drawCone(
+                scope,
+                seg.x1,
+                seg.y1,
+                seg.r1,
+                seg.x2,
+                seg.y2,
+                seg.r2,
+                seg.colourStart,
+                seg.colourEnd,
+            )
+        }
+    },
+})

--- a/astro/src/sketches/definitions/coneLines.ts
+++ b/astro/src/sketches/definitions/coneLines.ts
@@ -26,17 +26,24 @@ const COLOUR_PALETTE: HSB[] = [
     [200, 60, 75, 0.9],
 ]
 
-const NUM_SEGMENTS = 8
-const MIN_RADIUS = 10
-const MAX_RADIUS = 58
+const NUM_SEGMENTS = 5
+const MIN_RADIUS = 8
 /** Gaussian mean/sd for radius (clamped to min/max) – smaller so elements don’t fully overlap */
-const RADIUS_MEAN = 30
-const RADIUS_SD = 14
+const SMALL_RADIUS_MEAN = 14
+const SMALL_RADIUS_SD = 5
+/** Large circles up to 30% of canvas diameter; radius = 15% of smaller side */
+const LARGE_RADIUS_FRAC = 0.15
+const LARGE_RADIUS_MEAN_FRAC = 0.12
+const LARGE_RADIUS_SD_FRAC = 0.04
 /** Gaussian mean/sd for ratio of end radii (clamped); >1 = end often bigger, spread = more variety */
 const RATIO_MEAN = 1.1
 const RATIO_SD = 0.7
 const MIN_RATIO = 0.25
 const MAX_RATIO = 4.5
+
+const SHADOW_OFFSET_X = 14
+const SHADOW_OFFSET_Y = 14
+const SHADOW_COLOR = "rgba(0, 0, 0, 0.22)"
 
 /** Convert HSB [h 0–360, s 0–100, b 0–100, a 0–1] to CSS rgba() string */
 function hsbToRgba([h, s, b, a]: HSB): string {
@@ -107,6 +114,24 @@ function drawCone(
 
     const renderer = (scope as unknown as { _renderer?: { drawingContext: CanvasRenderingContext2D } })._renderer
     const ctx = renderer?.drawingContext
+
+    if (ctx) {
+        ctx.fillStyle = SHADOW_COLOR
+        ctx.beginPath()
+        ctx.moveTo(p1x + SHADOW_OFFSET_X, p1y + SHADOW_OFFSET_Y)
+        ctx.lineTo(p4x + SHADOW_OFFSET_X, p4y + SHADOW_OFFSET_Y)
+        ctx.lineTo(p3x + SHADOW_OFFSET_X, p3y + SHADOW_OFFSET_Y)
+        ctx.lineTo(p2x + SHADOW_OFFSET_X, p2y + SHADOW_OFFSET_Y)
+        ctx.closePath()
+        ctx.fill()
+        ctx.beginPath()
+        ctx.ellipse(x1 + SHADOW_OFFSET_X, y1 + SHADOW_OFFSET_Y, r1, r1, 0, 0, scope.TWO_PI)
+        ctx.fill()
+        ctx.beginPath()
+        ctx.ellipse(x2 + SHADOW_OFFSET_X, y2 + SHADOW_OFFSET_Y, r2, r2, 0, 0, scope.TWO_PI)
+        ctx.fill()
+    }
+
     if (ctx) {
         const startStyle = hsbToRgba(colourStart)
         const endStyle = hsbToRgba(colourEnd)
@@ -154,20 +179,26 @@ export default createSketch({
             randomSeed(seed)
             segments = []
             const { randomGaussian, constrain } = scope
+            const minDim = Math.min(width, height)
+            const maxRadius = minDim * LARGE_RADIUS_FRAC
             for (let i = 0; i < NUM_SEGMENTS; i++) {
                 const palette = COLOUR_PALETTE
                 const idx = () => Math.floor(random(palette.length))
+                const useLarge = random() > 0.5
                 const r1 = constrain(
-                    randomGaussian(RADIUS_MEAN, RADIUS_SD),
+                    randomGaussian(
+                        useLarge ? minDim * LARGE_RADIUS_MEAN_FRAC : SMALL_RADIUS_MEAN,
+                        useLarge ? minDim * LARGE_RADIUS_SD_FRAC : SMALL_RADIUS_SD,
+                    ),
                     MIN_RADIUS,
-                    MAX_RADIUS,
+                    maxRadius,
                 )
                 const ratio = constrain(
                     randomGaussian(RATIO_MEAN, RATIO_SD),
                     MIN_RATIO,
                     MAX_RATIO,
                 )
-                const r2 = constrain(r1 * ratio, MIN_RADIUS, MAX_RADIUS)
+                const r2 = constrain(r1 * ratio, MIN_RADIUS, maxRadius)
             segments.push({
                     x1: random(width * 0.1, width * 0.9),
                     y1: random(height * 0.1, height * 0.9),

--- a/astro/src/sketches/definitions/flowField.ts
+++ b/astro/src/sketches/definitions/flowField.ts
@@ -3,9 +3,10 @@ import type { SketchRegistrar } from "../types"
 const flowFieldSketch: SketchRegistrar = (p, getControls) => {
     const step = 18
     let appliedNoiseSeed: number | null = null
+    let canvasElement: HTMLCanvasElement | null = null
 
     const fitCanvasToParent = () => {
-        const parent = p.canvas?.parentElement
+        const parent = canvasElement?.parentElement
         if (!parent) return
 
         const width = Math.max(320, parent.clientWidth)
@@ -21,7 +22,8 @@ const flowFieldSketch: SketchRegistrar = (p, getControls) => {
     }
 
     p.setup = () => {
-        p.createCanvas(1, 1)
+        const renderer = p.createCanvas(1, 1)
+        canvasElement = renderer.elt as HTMLCanvasElement
         p.colorMode(p.HSB, 360, 100, 100, 1)
         p.noFill()
         p.strokeWeight(1.2)

--- a/astro/src/sketches/definitions/flowField.ts
+++ b/astro/src/sketches/definitions/flowField.ts
@@ -1,43 +1,14 @@
-import type { SketchRegistrar } from "../types"
+import { createSketch } from "../sketchCommon"
 
-const flowFieldSketch: SketchRegistrar = (p, getControls) => {
-    const step = 18
-    let appliedNoiseSeed: number | null = null
-    let canvasElement: HTMLCanvasElement | null = null
+const step = 18
 
-    const fitCanvasToParent = () => {
-        const parent = canvasElement?.parentElement
-        if (!parent) return
-
-        const width = Math.max(320, parent.clientWidth)
-        const height = Math.max(320, parent.clientHeight)
-        p.resizeCanvas(width, height, true)
-    }
-
-    const syncNoiseSeed = () => {
-        const { noiseSeed } = getControls()
-        if (appliedNoiseSeed === noiseSeed) return
-        p.noiseSeed(noiseSeed)
-        appliedNoiseSeed = noiseSeed
-    }
-
-    p.setup = () => {
-        const renderer = p.createCanvas(1, 1)
-        canvasElement = renderer.elt as HTMLCanvasElement
-        p.colorMode(p.HSB, 360, 100, 100, 1)
+export default createSketch({
+    setup(p) {
         p.noFill()
         p.strokeWeight(1.2)
-        fitCanvasToParent()
-    }
-
-    p.windowResized = () => {
-        fitCanvasToParent()
-    }
-
-    p.draw = () => {
+    },
+    draw(p, getControls) {
         const { reverse } = getControls()
-        syncNoiseSeed()
-
         p.background(212, 15, reverse ? 10 : 97)
 
         const direction = reverse ? -1 : 1
@@ -56,7 +27,5 @@ const flowFieldSketch: SketchRegistrar = (p, getControls) => {
                 p.line(x, y, x2, y2)
             }
         }
-    }
-}
-
-export default flowFieldSketch
+    },
+})

--- a/astro/src/sketches/definitions/flowField.ts
+++ b/astro/src/sketches/definitions/flowField.ts
@@ -1,0 +1,60 @@
+import type { SketchRegistrar } from "../types"
+
+const flowFieldSketch: SketchRegistrar = (p, getControls) => {
+    const step = 18
+    let appliedNoiseSeed: number | null = null
+
+    const fitCanvasToParent = () => {
+        const parent = p.canvas?.parentElement
+        if (!parent) return
+
+        const width = Math.max(320, parent.clientWidth)
+        const height = Math.max(320, parent.clientHeight)
+        p.resizeCanvas(width, height, true)
+    }
+
+    const syncNoiseSeed = () => {
+        const { noiseSeed } = getControls()
+        if (appliedNoiseSeed === noiseSeed) return
+        p.noiseSeed(noiseSeed)
+        appliedNoiseSeed = noiseSeed
+    }
+
+    p.setup = () => {
+        p.createCanvas(1, 1)
+        p.colorMode(p.HSB, 360, 100, 100, 1)
+        p.noFill()
+        p.strokeWeight(1.2)
+        fitCanvasToParent()
+    }
+
+    p.windowResized = () => {
+        fitCanvasToParent()
+    }
+
+    p.draw = () => {
+        const { reverse } = getControls()
+        syncNoiseSeed()
+
+        p.background(212, 15, reverse ? 10 : 97)
+
+        const direction = reverse ? -1 : 1
+        const animationTime = p.frameCount * 0.004
+
+        for (let y = step; y < p.height; y += step) {
+            for (let x = step; x < p.width; x += step) {
+                const value = p.noise(x * 0.004, y * 0.004, animationTime)
+                const angle = value * p.TWO_PI * 2.4 * direction
+                const segmentLength = step * 0.8
+                const x2 = x + Math.cos(angle) * segmentLength
+                const y2 = y + Math.sin(angle) * segmentLength
+
+                const hue = (value * 260 + p.frameCount * 0.25) % 360
+                p.stroke(hue, reverse ? 35 : 68, reverse ? 96 : 30, 0.82)
+                p.line(x, y, x2, y2)
+            }
+        }
+    }
+}
+
+export default flowFieldSketch

--- a/astro/src/sketches/definitions/flowField.ts
+++ b/astro/src/sketches/definitions/flowField.ts
@@ -3,28 +3,28 @@ import { createSketch } from "../sketchCommon"
 const step = 18
 
 export default createSketch({
-    setup(p) {
-        p.noFill()
-        p.strokeWeight(1.2)
+    setup(scope) {
+        const { noFill, strokeWeight } = scope
+        noFill()
+        strokeWeight(1.2)
     },
-    draw(p, getControls) {
-        const { reverse } = getControls()
-        p.background(212, 15, reverse ? 10 : 97)
+    draw(scope) {
+        const { background, noise, stroke, line, width, height, frameCount, TWO_PI } = scope
+        background(212, 15, 97)
 
-        const direction = reverse ? -1 : 1
-        const animationTime = p.frameCount * 0.004
+        const animationTime = frameCount * 0.004
 
-        for (let y = step; y < p.height; y += step) {
-            for (let x = step; x < p.width; x += step) {
-                const value = p.noise(x * 0.004, y * 0.004, animationTime)
-                const angle = value * p.TWO_PI * 2.4 * direction
+        for (let y = step; y < height; y += step) {
+            for (let x = step; x < width; x += step) {
+                const value = noise(x * 0.004, y * 0.004, animationTime)
+                const angle = value * TWO_PI * 2.4
                 const segmentLength = step * 0.8
                 const x2 = x + Math.cos(angle) * segmentLength
                 const y2 = y + Math.sin(angle) * segmentLength
 
-                const hue = (value * 260 + p.frameCount * 0.25) % 360
-                p.stroke(hue, reverse ? 35 : 68, reverse ? 96 : 30, 0.82)
-                p.line(x, y, x2, y2)
+                const hue = (value * 260 + frameCount * 0.25) % 360
+                stroke(hue, 68, 30, 0.82)
+                line(x, y, x2, y2)
             }
         }
     },

--- a/astro/src/sketches/definitions/fractal1.ts
+++ b/astro/src/sketches/definitions/fractal1.ts
@@ -1,33 +1,38 @@
 import type p5 from "p5"
 import { createSketch } from "../sketchCommon"
 
-const MAX_DEPTH = 12
-const SCALE = 0.72
-const PADDING = 0.08
+const MAX_DEPTH = 10
+const BRANCH_SCALE_MIN = 0.58
+const BRANCH_SCALE_MAX = 0.78
+const BRANCH_SPREAD_MIN = 0.25
+const BRANCH_SPREAD_MAX = 0.58
+const TRUNK_LENGTH_RATIO = 0.22
 
-function drawNestedRects(
+function drawBranch(
     scope: p5,
     x: number,
     y: number,
-    w: number,
-    h: number,
+    angle: number,
+    length: number,
     depth: number,
 ) {
-    if (depth <= 0 || w < 4 || h < 4) return
+    if (depth <= 0 || length < 2) return
 
-    const hue = (280 - depth * 22 + scope.frameCount * 0.3) % 360
-    scope.stroke(hue, 70, 90, 0.95)
-    scope.strokeWeight(Math.max(0.8, 2 - depth * 0.12))
-    scope.rect(x, y, w, h)
+    const x2 = x + Math.cos(angle) * length
+    const y2 = y + Math.sin(angle) * length
 
-    const padX = w * PADDING
-    const padY = h * PADDING
-    const innerW = (w - 2 * padX) * SCALE
-    const innerH = (h - 2 * padY) * SCALE
-    const innerX = x + (w - innerW) / 2
-    const innerY = y + (h - innerH) / 2
+    const hue = (120 - depth * 8 + scope.frameCount * 0.15) % 360
+    scope.stroke(hue, 55, 40, 0.9)
+    scope.strokeWeight(Math.max(1, 4 - depth * 0.35))
+    scope.line(x, y, x2, y2)
 
-    drawNestedRects(scope, innerX, innerY, innerW, innerH, depth - 1)
+    const spreadLeft = scope.random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
+    const spreadRight = scope.random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
+    const scaleLeft = scope.random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
+    const scaleRight = scope.random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
+
+    drawBranch(scope, x2, y2, angle - spreadLeft, length * scaleLeft, depth - 1)
+    drawBranch(scope, x2, y2, angle + spreadRight, length * scaleRight, depth - 1)
 }
 
 export default createSketch({
@@ -35,14 +40,16 @@ export default createSketch({
         const { noFill } = scope
         noFill()
     },
-    draw(scope) {
-        const { background, width, height } = scope
-        background(260, 12, 98)
+    draw(scope, getControls) {
+        const { background, width, height, randomSeed } = scope
+        randomSeed(getControls().randomSeed)
+        background(200, 18, 98)
 
-        const margin = Math.min(width, height) * 0.06
-        const w = width - 2 * margin
-        const h = height - 2 * margin
+        const trunkLength = Math.min(width, height) * TRUNK_LENGTH_RATIO
+        const startX = width / 2
+        const startY = height * 0.92
+        const trunkAngle = -Math.PI / 2
 
-        drawNestedRects(scope, margin, margin, w, h, MAX_DEPTH)
+        drawBranch(scope, startX, startY, trunkAngle, trunkLength, MAX_DEPTH)
     },
 })

--- a/astro/src/sketches/definitions/fractal1.ts
+++ b/astro/src/sketches/definitions/fractal1.ts
@@ -56,11 +56,11 @@ export default createSketch({
 
         const h = r * 0.75
         const x0 = cx
-        const y0 = cy - h
+        const y0 = cy - (4 * h) / 3
         const x1 = cx - r * (Math.sqrt(3) / 2)
-        const y1 = cy + h
+        const y1 = cy + (2 * h) / 3
         const x2 = cx + r * (Math.sqrt(3) / 2)
-        const y2 = cy + h
+        const y2 = cy + (2 * h) / 3
 
         drawNestedTriangles(scope, x0, y0, x1, y1, x2, y2, MAX_DEPTH)
     },

--- a/astro/src/sketches/definitions/fractal1.ts
+++ b/astro/src/sketches/definitions/fractal1.ts
@@ -1,39 +1,44 @@
 import type p5 from "p5"
 import { createSketch } from "../sketchCommon"
 
-const MAX_DEPTH = 10
-const BRANCH_SCALE_MIN = 0.58
-const BRANCH_SCALE_MAX = 0.78
-const BRANCH_SPREAD_MIN = 0.25
-const BRANCH_SPREAD_MAX = 0.58
-const TRUNK_LENGTH_RATIO = 0.22
+const MAX_DEPTH = 12
+const INNER_BASE_START = 0.12
+const INNER_BASE_END = 0.88
 
-function drawBranch(
+function drawNestedTriangles(
     scope: p5,
-    x: number,
-    y: number,
-    angle: number,
-    length: number,
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
     depth: number,
 ) {
-    const { stroke, strokeWeight, line, random, frameCount } = scope
-    if (depth <= 0 || length < 2) return
+    const { stroke, strokeWeight, triangle: drawTriangle } = scope
+    if (depth <= 0) return
 
-    const x2 = x + Math.cos(angle) * length
-    const y2 = y + Math.sin(angle) * length
+    stroke(0, 0, 0)
+    strokeWeight(Math.max(0.8, 2.5 - depth * 0.25))
+    drawTriangle(x0, y0, x1, y1, x2, y2)
 
-    const hue = (120 - depth * 8 + frameCount * 0.15) % 360
-    stroke(hue, 55, 40, 0.9)
-    strokeWeight(Math.max(1, 4 - depth * 0.35))
-    line(x, y, x2, y2)
+    const baseLeftX = x0 + (x1 - x0) * INNER_BASE_START
+    const baseLeftY = y0 + (y1 - y0) * INNER_BASE_START
+    const baseRightX = x0 + (x1 - x0) * INNER_BASE_END
+    const baseRightY = y0 + (y1 - y0) * INNER_BASE_END
+    const apexX = (x0 + x1 + x2) / 3
+    const apexY = (y0 + y1 + y2) / 3
 
-    const spreadLeft = random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
-    const spreadRight = random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
-    const scaleLeft = random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
-    const scaleRight = random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
-
-    drawBranch(scope, x2, y2, angle - spreadLeft, length * scaleLeft, depth - 1)
-    drawBranch(scope, x2, y2, angle + spreadRight, length * scaleRight, depth - 1)
+    drawNestedTriangles(
+        scope,
+        baseLeftX,
+        baseLeftY,
+        baseRightX,
+        baseRightY,
+        apexX,
+        apexY,
+        depth - 1,
+    )
 }
 
 export default createSketch({
@@ -41,16 +46,22 @@ export default createSketch({
         const { noFill } = scope
         noFill()
     },
-    draw(scope, getControls) {
-        const { background, width, height, randomSeed } = scope
-        randomSeed(getControls().randomSeed)
-        background(200, 18, 98)
+    draw(scope) {
+        const { background, width, height } = scope
+        background(0, 0, 85)
 
-        const trunkLength = Math.min(width, height) * TRUNK_LENGTH_RATIO
-        const startX = width / 2
-        const startY = height * 0.92
-        const trunkAngle = -Math.PI / 2
+        const cx = width / 2
+        const cy = height / 2
+        const r = Math.min(width, height) * 0.42
 
-        drawBranch(scope, startX, startY, trunkAngle, trunkLength, MAX_DEPTH)
+        const h = r * 0.75
+        const x0 = cx
+        const y0 = cy - h
+        const x1 = cx - r * (Math.sqrt(3) / 2)
+        const y1 = cy + h
+        const x2 = cx + r * (Math.sqrt(3) / 2)
+        const y2 = cy + h
+
+        drawNestedTriangles(scope, x0, y0, x1, y1, x2, y2, MAX_DEPTH)
     },
 })

--- a/astro/src/sketches/definitions/fractal1.ts
+++ b/astro/src/sketches/definitions/fractal1.ts
@@ -16,20 +16,21 @@ function drawBranch(
     length: number,
     depth: number,
 ) {
+    const { stroke, strokeWeight, line, random, frameCount } = scope
     if (depth <= 0 || length < 2) return
 
     const x2 = x + Math.cos(angle) * length
     const y2 = y + Math.sin(angle) * length
 
-    const hue = (120 - depth * 8 + scope.frameCount * 0.15) % 360
-    scope.stroke(hue, 55, 40, 0.9)
-    scope.strokeWeight(Math.max(1, 4 - depth * 0.35))
-    scope.line(x, y, x2, y2)
+    const hue = (120 - depth * 8 + frameCount * 0.15) % 360
+    stroke(hue, 55, 40, 0.9)
+    strokeWeight(Math.max(1, 4 - depth * 0.35))
+    line(x, y, x2, y2)
 
-    const spreadLeft = scope.random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
-    const spreadRight = scope.random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
-    const scaleLeft = scope.random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
-    const scaleRight = scope.random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
+    const spreadLeft = random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
+    const spreadRight = random(BRANCH_SPREAD_MIN, BRANCH_SPREAD_MAX)
+    const scaleLeft = random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
+    const scaleRight = random(BRANCH_SCALE_MIN, BRANCH_SCALE_MAX)
 
     drawBranch(scope, x2, y2, angle - spreadLeft, length * scaleLeft, depth - 1)
     drawBranch(scope, x2, y2, angle + spreadRight, length * scaleRight, depth - 1)

--- a/astro/src/sketches/definitions/fractal1.ts
+++ b/astro/src/sketches/definitions/fractal1.ts
@@ -1,0 +1,48 @@
+import type p5 from "p5"
+import { createSketch } from "../sketchCommon"
+
+const MAX_DEPTH = 12
+const SCALE = 0.72
+const PADDING = 0.08
+
+function drawNestedRects(
+    scope: p5,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    depth: number,
+) {
+    if (depth <= 0 || w < 4 || h < 4) return
+
+    const hue = (280 - depth * 22 + scope.frameCount * 0.3) % 360
+    scope.stroke(hue, 70, 90, 0.95)
+    scope.strokeWeight(Math.max(0.8, 2 - depth * 0.12))
+    scope.rect(x, y, w, h)
+
+    const padX = w * PADDING
+    const padY = h * PADDING
+    const innerW = (w - 2 * padX) * SCALE
+    const innerH = (h - 2 * padY) * SCALE
+    const innerX = x + (w - innerW) / 2
+    const innerY = y + (h - innerH) / 2
+
+    drawNestedRects(scope, innerX, innerY, innerW, innerH, depth - 1)
+}
+
+export default createSketch({
+    setup(scope) {
+        const { noFill } = scope
+        noFill()
+    },
+    draw(scope) {
+        const { background, width, height } = scope
+        background(260, 12, 98)
+
+        const margin = Math.min(width, height) * 0.06
+        const w = width - 2 * margin
+        const h = height - 2 * margin
+
+        drawNestedRects(scope, margin, margin, w, h, MAX_DEPTH)
+    },
+})

--- a/astro/src/sketches/definitions/noiseDunes.ts
+++ b/astro/src/sketches/definitions/noiseDunes.ts
@@ -1,40 +1,10 @@
-import type { SketchRegistrar } from "../types"
+import { createSketch } from "../sketchCommon"
 
-const noiseDunesSketch: SketchRegistrar = (p, getControls) => {
-    let appliedNoiseSeed: number | null = null
-    let canvasElement: HTMLCanvasElement | null = null
-
-    const fitCanvasToParent = () => {
-        const parent = canvasElement?.parentElement
-        if (!parent) return
-
-        const width = Math.max(320, parent.clientWidth)
-        const height = Math.max(320, parent.clientHeight)
-        p.resizeCanvas(width, height, true)
-    }
-
-    const syncNoiseSeed = () => {
-        const { noiseSeed } = getControls()
-        if (appliedNoiseSeed === noiseSeed) return
-        p.noiseSeed(noiseSeed)
-        appliedNoiseSeed = noiseSeed
-    }
-
-    p.setup = () => {
-        const renderer = p.createCanvas(1, 1)
-        canvasElement = renderer.elt as HTMLCanvasElement
-        p.colorMode(p.HSB, 360, 100, 100, 1)
+export default createSketch({
+    setup(p) {
         p.noFill()
-        fitCanvasToParent()
-    }
-
-    p.windowResized = () => {
-        fitCanvasToParent()
-    }
-
-    p.draw = () => {
-        syncNoiseSeed()
-
+    },
+    draw(p) {
         p.background(220, 14, 96)
 
         const rows = 52
@@ -54,7 +24,5 @@ const noiseDunesSketch: SketchRegistrar = (p, getControls) => {
             }
             p.endShape()
         }
-    }
-}
-
-export default noiseDunesSketch
+    },
+})

--- a/astro/src/sketches/definitions/noiseDunes.ts
+++ b/astro/src/sketches/definitions/noiseDunes.ts
@@ -1,28 +1,30 @@
 import { createSketch } from "../sketchCommon"
 
 export default createSketch({
-    setup(p) {
-        p.noFill()
+    setup(scope) {
+        const { noFill } = scope
+        noFill()
     },
-    draw(p) {
-        p.background(220, 14, 96)
+    draw(scope) {
+        const { background, noise, stroke, beginShape, endShape, vertex, map, width, height, frameCount } = scope
+        background(220, 14, 96)
 
         const rows = 52
-        const amplitude = Math.min(90, p.height * 0.14)
-        const t = p.frameCount * 0.0025
+        const amplitude = Math.min(90, height * 0.14)
+        const t = frameCount * 0.0025
 
         for (let row = 0; row < rows; row++) {
             const depth = row / Math.max(1, rows - 1)
-            const yBase = p.map(depth, 0, 1, p.height * 0.08, p.height * 0.92)
+            const yBase = map(depth, 0, 1, height * 0.08, height * 0.92)
 
-            p.stroke(210 + depth * 20, 58, 28 + depth * 30, 0.9)
-            p.beginShape()
-            for (let x = 0; x <= p.width; x += 12) {
-                const waveNoise = p.noise(x * 0.0034, row * 0.08, t)
+            stroke(210 + depth * 20, 58, 28 + depth * 30, 0.9)
+            beginShape()
+            for (let x = 0; x <= width; x += 12) {
+                const waveNoise = noise(x * 0.0034, row * 0.08, t)
                 const yOffset = (waveNoise - 0.5) * amplitude * (0.25 + depth)
-                p.vertex(x, yBase + yOffset)
+                vertex(x, yBase + yOffset)
             }
-            p.endShape()
+            endShape()
         }
     },
 })

--- a/astro/src/sketches/definitions/noiseDunes.ts
+++ b/astro/src/sketches/definitions/noiseDunes.ts
@@ -2,9 +2,10 @@ import type { SketchRegistrar } from "../types"
 
 const noiseDunesSketch: SketchRegistrar = (p, getControls) => {
     let appliedNoiseSeed: number | null = null
+    let canvasElement: HTMLCanvasElement | null = null
 
     const fitCanvasToParent = () => {
-        const parent = p.canvas?.parentElement
+        const parent = canvasElement?.parentElement
         if (!parent) return
 
         const width = Math.max(320, parent.clientWidth)
@@ -20,7 +21,8 @@ const noiseDunesSketch: SketchRegistrar = (p, getControls) => {
     }
 
     p.setup = () => {
-        p.createCanvas(1, 1)
+        const renderer = p.createCanvas(1, 1)
+        canvasElement = renderer.elt as HTMLCanvasElement
         p.colorMode(p.HSB, 360, 100, 100, 1)
         p.noFill()
         fitCanvasToParent()

--- a/astro/src/sketches/definitions/noiseDunes.ts
+++ b/astro/src/sketches/definitions/noiseDunes.ts
@@ -1,0 +1,58 @@
+import type { SketchRegistrar } from "../types"
+
+const noiseDunesSketch: SketchRegistrar = (p, getControls) => {
+    let appliedNoiseSeed: number | null = null
+
+    const fitCanvasToParent = () => {
+        const parent = p.canvas?.parentElement
+        if (!parent) return
+
+        const width = Math.max(320, parent.clientWidth)
+        const height = Math.max(320, parent.clientHeight)
+        p.resizeCanvas(width, height, true)
+    }
+
+    const syncNoiseSeed = () => {
+        const { noiseSeed } = getControls()
+        if (appliedNoiseSeed === noiseSeed) return
+        p.noiseSeed(noiseSeed)
+        appliedNoiseSeed = noiseSeed
+    }
+
+    p.setup = () => {
+        p.createCanvas(1, 1)
+        p.colorMode(p.HSB, 360, 100, 100, 1)
+        p.noFill()
+        fitCanvasToParent()
+    }
+
+    p.windowResized = () => {
+        fitCanvasToParent()
+    }
+
+    p.draw = () => {
+        syncNoiseSeed()
+
+        p.background(220, 14, 96)
+
+        const rows = 52
+        const amplitude = Math.min(90, p.height * 0.14)
+        const t = p.frameCount * 0.0025
+
+        for (let row = 0; row < rows; row++) {
+            const depth = row / Math.max(1, rows - 1)
+            const yBase = p.map(depth, 0, 1, p.height * 0.08, p.height * 0.92)
+
+            p.stroke(210 + depth * 20, 58, 28 + depth * 30, 0.9)
+            p.beginShape()
+            for (let x = 0; x <= p.width; x += 12) {
+                const waveNoise = p.noise(x * 0.0034, row * 0.08, t)
+                const yOffset = (waveNoise - 0.5) * amplitude * (0.25 + depth)
+                p.vertex(x, yBase + yOffset)
+            }
+            p.endShape()
+        }
+    }
+}
+
+export default noiseDunesSketch

--- a/astro/src/sketches/registry.ts
+++ b/astro/src/sketches/registry.ts
@@ -1,73 +1,19 @@
-import {
-    DEFAULT_SKETCH_CONTROLS,
-    mergeSketchControls,
-    type SketchModule,
-    type SketchRegistryItem,
-    type SketchControls,
-} from "./types"
+import type { SketchModule } from "./types"
 
 const sketchModules = import.meta.glob<SketchModule>("./definitions/*.ts")
 
-const registry: SketchRegistryItem[] = [
-    {
-        slug: "flow-field",
-        title: "Flow Field",
-        date: "2026-02-28",
-        modulePath: "./definitions/flowField.ts",
-        defaultControls: {
-            noiseSeed: 1823,
-            randomSeed: 45678,
-        },
-    },
-    {
-        slug: "noise-dunes",
-        title: "Noise Dunes",
-        date: "2026-02-20",
-        modulePath: "./definitions/noiseDunes.ts",
-        defaultControls: {
-            noiseSeed: 927,
-            randomSeed: 29384,
-        },
-    },
-    {
-        slug: "fractal1",
-        title: "Fractal 1",
-        date: "2026-03-01",
-        modulePath: "./definitions/fractal1.ts",
-        defaultControls: {
-            noiseSeed: 12345,
-            randomSeed: 78901,
-        },
-    },
-]
-
-const toTimestamp = (value: string): number => {
-    const parsedValue = Date.parse(value)
-    return Number.isNaN(parsedValue) ? 0 : parsedValue
-}
-
-export const sketchRegistry = [...registry].sort((a, b) => toTimestamp(b.date) - toTimestamp(a.date))
-
-export function getSketchBySlug(slug: string): SketchRegistryItem | undefined {
-    return sketchRegistry.find(sketch => sketch.slug === slug)
-}
-
-export function getLatestSketch(): SketchRegistryItem | undefined {
-    return sketchRegistry[0]
-}
-
-export function getDefaultControlsForSketch(slug: string): SketchControls {
-    const sketch = getSketchBySlug(slug)
-    if (!sketch) return DEFAULT_SKETCH_CONTROLS
-    return mergeSketchControls(sketch.defaultControls, DEFAULT_SKETCH_CONTROLS)
+/** Maps collection entry id (e.g. "flow-field") to module path (e.g. "./definitions/flowField.ts") */
+export function slugToModulePath(slug: string): string {
+    const filename = slug
+        .split("-")
+        .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+        .join("")
+    return `./definitions/${filename}.ts`
 }
 
 export async function loadSketchModule(slug: string): Promise<SketchModule | null> {
-    const sketch = getSketchBySlug(slug)
-    if (!sketch) return null
-
-    const loader = sketchModules[sketch.modulePath]
+    const modulePath = slugToModulePath(slug)
+    const loader = sketchModules[modulePath]
     if (!loader) return null
-
     return loader()
 }

--- a/astro/src/sketches/registry.ts
+++ b/astro/src/sketches/registry.ts
@@ -1,0 +1,63 @@
+import {
+    DEFAULT_SKETCH_CONTROLS,
+    mergeSketchControls,
+    type SketchModule,
+    type SketchRegistryItem,
+    type SketchControls,
+} from "./types"
+
+const sketchModules = import.meta.glob<SketchModule>("./definitions/*.ts")
+
+const registry: SketchRegistryItem[] = [
+    {
+        slug: "flow-field",
+        title: "Flow Field",
+        date: "2026-02-28",
+        modulePath: "./definitions/flowField.ts",
+        defaultControls: {
+            reverse: false,
+            noiseSeed: 1823,
+        },
+    },
+    {
+        slug: "noise-dunes",
+        title: "Noise Dunes",
+        date: "2026-02-20",
+        modulePath: "./definitions/noiseDunes.ts",
+        defaultControls: {
+            reverse: false,
+            noiseSeed: 927,
+        },
+    },
+]
+
+const toTimestamp = (value: string): number => {
+    const parsedValue = Date.parse(value)
+    return Number.isNaN(parsedValue) ? 0 : parsedValue
+}
+
+export const sketchRegistry = [...registry].sort((a, b) => toTimestamp(b.date) - toTimestamp(a.date))
+
+export function getSketchBySlug(slug: string): SketchRegistryItem | undefined {
+    return sketchRegistry.find(sketch => sketch.slug === slug)
+}
+
+export function getLatestSketch(): SketchRegistryItem | undefined {
+    return sketchRegistry[0]
+}
+
+export function getDefaultControlsForSketch(slug: string): SketchControls {
+    const sketch = getSketchBySlug(slug)
+    if (!sketch) return DEFAULT_SKETCH_CONTROLS
+    return mergeSketchControls(sketch.defaultControls, DEFAULT_SKETCH_CONTROLS)
+}
+
+export async function loadSketchModule(slug: string): Promise<SketchModule | null> {
+    const sketch = getSketchBySlug(slug)
+    if (!sketch) return null
+
+    const loader = sketchModules[sketch.modulePath]
+    if (!loader) return null
+
+    return loader()
+}

--- a/astro/src/sketches/registry.ts
+++ b/astro/src/sketches/registry.ts
@@ -16,6 +16,7 @@ const registry: SketchRegistryItem[] = [
         modulePath: "./definitions/flowField.ts",
         defaultControls: {
             noiseSeed: 1823,
+            randomSeed: 45678,
         },
     },
     {
@@ -25,6 +26,7 @@ const registry: SketchRegistryItem[] = [
         modulePath: "./definitions/noiseDunes.ts",
         defaultControls: {
             noiseSeed: 927,
+            randomSeed: 29384,
         },
     },
     {
@@ -32,6 +34,10 @@ const registry: SketchRegistryItem[] = [
         title: "Fractal 1",
         date: "2026-03-01",
         modulePath: "./definitions/fractal1.ts",
+        defaultControls: {
+            noiseSeed: 12345,
+            randomSeed: 78901,
+        },
     },
 ]
 

--- a/astro/src/sketches/registry.ts
+++ b/astro/src/sketches/registry.ts
@@ -15,7 +15,6 @@ const registry: SketchRegistryItem[] = [
         date: "2026-02-28",
         modulePath: "./definitions/flowField.ts",
         defaultControls: {
-            reverse: false,
             noiseSeed: 1823,
         },
     },
@@ -25,9 +24,14 @@ const registry: SketchRegistryItem[] = [
         date: "2026-02-20",
         modulePath: "./definitions/noiseDunes.ts",
         defaultControls: {
-            reverse: false,
             noiseSeed: 927,
         },
+    },
+    {
+        slug: "fractal1",
+        title: "Fractal 1",
+        date: "2026-03-01",
+        modulePath: "./definitions/fractal1.ts",
     },
 ]
 

--- a/astro/src/sketches/sketchCommon.ts
+++ b/astro/src/sketches/sketchCommon.ts
@@ -23,8 +23,8 @@ export function createSketch(definition: SketchDefinition): SketchRegistrar {
     const fitCanvasToParent = (p: p5) => {
         const parent = canvasElement?.parentElement
         if (!parent) return
-        const width = Math.max(320, parent.clientWidth)
-        const height = Math.max(320, parent.clientHeight)
+        const width = Math.max(1, parent.clientWidth)
+        const height = Math.max(1, parent.clientHeight)
         p.resizeCanvas(width, height, true)
     }
 

--- a/astro/src/sketches/sketchCommon.ts
+++ b/astro/src/sketches/sketchCommon.ts
@@ -1,0 +1,46 @@
+import type p5 from "p5"
+import type { SketchControls, SketchRegistrar } from "./types"
+
+export interface SketchDefinition {
+    setup?: (p: p5) => void
+    draw: (p: p5, getControls: () => SketchControls) => void
+}
+
+export function createSketch(definition: SketchDefinition): SketchRegistrar {
+    let canvasElement: HTMLCanvasElement | null = null
+    let appliedNoiseSeed: number | null = null
+
+    const fitCanvasToParent = (p: p5) => {
+        const parent = canvasElement?.parentElement
+        if (!parent) return
+        const width = Math.max(320, parent.clientWidth)
+        const height = Math.max(320, parent.clientHeight)
+        p.resizeCanvas(width, height, true)
+    }
+
+    const syncNoiseSeed = (p: p5, getControls: () => SketchControls) => {
+        const { noiseSeed } = getControls()
+        if (appliedNoiseSeed === noiseSeed) return
+        p.noiseSeed(noiseSeed)
+        appliedNoiseSeed = noiseSeed
+    }
+
+    return (p, getControls) => {
+        p.setup = () => {
+            const renderer = p.createCanvas(1, 1)
+            canvasElement = renderer.elt as HTMLCanvasElement
+            p.colorMode(p.HSB, 360, 100, 100, 1)
+            fitCanvasToParent(p)
+            definition.setup?.(p)
+        }
+
+        p.windowResized = () => {
+            fitCanvasToParent(p)
+        }
+
+        p.draw = () => {
+            syncNoiseSeed(p, getControls)
+            definition.draw(p, getControls)
+        }
+    }
+}

--- a/astro/src/sketches/sketchCommon.ts
+++ b/astro/src/sketches/sketchCommon.ts
@@ -1,9 +1,19 @@
 import type p5 from "p5"
 import type { SketchControls, SketchRegistrar } from "./types"
 
+/** p5 instance wrapped so you can destructure and call methods without a prefix, e.g. const { background, rect } = scope */
+export function createScope(p: p5): p5 {
+    return new Proxy(p, {
+        get(target, prop) {
+            const value = (target as unknown as Record<string | symbol, unknown>)[prop]
+            return typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(target) : value
+        },
+    }) as p5
+}
+
 export interface SketchDefinition {
-    setup?: (p: p5) => void
-    draw: (p: p5, getControls: () => SketchControls) => void
+    setup?: (scope: p5) => void
+    draw: (scope: p5, getControls: () => SketchControls) => void
 }
 
 export function createSketch(definition: SketchDefinition): SketchRegistrar {
@@ -26,12 +36,14 @@ export function createSketch(definition: SketchDefinition): SketchRegistrar {
     }
 
     return (p, getControls) => {
+        const scope = createScope(p)
+
         p.setup = () => {
             const renderer = p.createCanvas(1, 1)
             canvasElement = renderer.elt as HTMLCanvasElement
             p.colorMode(p.HSB, 360, 100, 100, 1)
             fitCanvasToParent(p)
-            definition.setup?.(p)
+            definition.setup?.(scope)
         }
 
         p.windowResized = () => {
@@ -40,7 +52,7 @@ export function createSketch(definition: SketchDefinition): SketchRegistrar {
 
         p.draw = () => {
             syncNoiseSeed(p, getControls)
-            definition.draw(p, getControls)
+            definition.draw(scope, getControls)
         }
     }
 }

--- a/astro/src/sketches/sketchCommon.ts
+++ b/astro/src/sketches/sketchCommon.ts
@@ -21,8 +21,8 @@ export function createSketch(definition: SketchDefinition): SketchRegistrar {
     let appliedNoiseSeed: number | null = null
 
     const fitCanvasToParent = (p: p5) => {
-        const parent = canvasElement?.parentElement
-        if (!parent) return
+        if (!canvasElement?.parentElement || !document.contains(canvasElement)) return
+        const parent = canvasElement.parentElement
         const width = Math.max(1, parent.clientWidth)
         const height = Math.max(1, parent.clientHeight)
         p.resizeCanvas(width, height, true)
@@ -43,6 +43,11 @@ export function createSketch(definition: SketchDefinition): SketchRegistrar {
             canvasElement = renderer.elt as HTMLCanvasElement
             p.colorMode(p.HSB, 360, 100, 100, 1)
             fitCanvasToParent(p)
+            const parent = canvasElement.parentElement
+            if (parent) {
+                const resizeObserver = new ResizeObserver(() => fitCanvasToParent(p))
+                resizeObserver.observe(parent)
+            }
             definition.setup?.(scope)
         }
 

--- a/astro/src/sketches/types.ts
+++ b/astro/src/sketches/types.ts
@@ -2,6 +2,7 @@ import type p5 from "p5"
 
 export interface SketchControls {
     noiseSeed: number
+    randomSeed: number
 }
 
 export interface SketchRegistryItem {
@@ -20,6 +21,7 @@ export interface SketchModule {
 
 export const DEFAULT_SKETCH_CONTROLS: SketchControls = {
     noiseSeed: 1234,
+    randomSeed: 5678,
 }
 
 export function mergeSketchControls(
@@ -29,8 +31,12 @@ export function mergeSketchControls(
     const parsedNoiseSeed = Number.isFinite(overrides.noiseSeed)
         ? Math.trunc(overrides.noiseSeed as number)
         : base.noiseSeed
+    const parsedRandomSeed = Number.isFinite(overrides.randomSeed)
+        ? Math.trunc(overrides.randomSeed as number)
+        : base.randomSeed
 
     return {
         noiseSeed: parsedNoiseSeed,
+        randomSeed: parsedRandomSeed,
     }
 }

--- a/astro/src/sketches/types.ts
+++ b/astro/src/sketches/types.ts
@@ -1,7 +1,6 @@
 import type p5 from "p5"
 
 export interface SketchControls {
-    reverse: boolean
     noiseSeed: number
 }
 
@@ -20,7 +19,6 @@ export interface SketchModule {
 }
 
 export const DEFAULT_SKETCH_CONTROLS: SketchControls = {
-    reverse: false,
     noiseSeed: 1234,
 }
 
@@ -33,7 +31,6 @@ export function mergeSketchControls(
         : base.noiseSeed
 
     return {
-        reverse: typeof overrides.reverse === "boolean" ? overrides.reverse : base.reverse,
         noiseSeed: parsedNoiseSeed,
     }
 }

--- a/astro/src/sketches/types.ts
+++ b/astro/src/sketches/types.ts
@@ -1,0 +1,39 @@
+import type p5 from "p5"
+
+export interface SketchControls {
+    reverse: boolean
+    noiseSeed: number
+}
+
+export interface SketchRegistryItem {
+    slug: string
+    title: string
+    date: string
+    modulePath: string
+    defaultControls?: Partial<SketchControls>
+}
+
+export type SketchRegistrar = (p: p5, getControls: () => SketchControls) => void
+
+export interface SketchModule {
+    default: SketchRegistrar
+}
+
+export const DEFAULT_SKETCH_CONTROLS: SketchControls = {
+    reverse: false,
+    noiseSeed: 1234,
+}
+
+export function mergeSketchControls(
+    overrides: Partial<SketchControls> = {},
+    base: SketchControls = DEFAULT_SKETCH_CONTROLS,
+): SketchControls {
+    const parsedNoiseSeed = Number.isFinite(overrides.noiseSeed)
+        ? Math.trunc(overrides.noiseSeed as number)
+        : base.noiseSeed
+
+    return {
+        reverse: typeof overrides.reverse === "boolean" ? overrides.reverse : base.reverse,
+        noiseSeed: parsedNoiseSeed,
+    }
+}

--- a/astro/src/sketches/types.ts
+++ b/astro/src/sketches/types.ts
@@ -5,14 +5,6 @@ export interface SketchControls {
     randomSeed: number
 }
 
-export interface SketchRegistryItem {
-    slug: string
-    title: string
-    date: string
-    modulePath: string
-    defaultControls?: Partial<SketchControls>
-}
-
 export type SketchRegistrar = (p: p5, getControls: () => SketchControls) => void
 
 export interface SketchModule {


### PR DESCRIPTION
Add a `/sketches` page with a dynamic p5 sketch runner, sidebar navigation, and shared controls.

This PR implements a dedicated section for p5 sketches, allowing users to browse and interact with different sketches via a left sidebar (desktop) or mobile menu, with controls like `reverse` and `noiseSeed` persisting in URL query parameters. The `/sketches` root redirects to the most recent sketch, and invalid slugs display a "Sketch not found" page.

---
<p><a href="https://cursor.com/agents/bc-bacd2828-5416-476f-8793-bd975c7ceae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bacd2828-5416-476f-8793-bd975c7ceae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

