### PR TITLE
Add article: How to calculate pixels for any print size at 300 DPI

### DIFF
--- a/astro/src/content/articles/print-size-pixels-300dpi.md
+++ b/astro/src/content/articles/print-size-pixels-300dpi.md
@@ -1,0 +1,51 @@
+---
+title: How to calculate pixels for any print size at 300 DPI
+description: Pick your print size first, then work out the pixel dimensions you need at 300 DPI so the print stays sharp.
+pubDate: 2026-08-05
+---
+
+Ok, you’ve got your artwork algorithm working. Now you want to generate an image that can actually print sharp at 300 DPI for a specific paper size.
+
+That’s the right way round. Instead of making a small file and hoping it scales, decide the print size first, then generate enough pixels for it.
+
+## Start with the print size
+
+First, decide how big you want the print to be — A4, A3, A2, or a custom size.
+
+Once you know the final paper size, the pixel question becomes simple maths.
+
+## What 300 DPI means
+
+300 DPI just means 300 pixels for every inch of paper.
+
+So if your print is 10 inches wide, you need 10 × 300 = 3000 pixels across. Same idea for the height. That’s the usual target for a sharp art print.
+
+## The formula
+
+Multiply the print width and height in inches by 300.
+
+```
+pixels = inches × 300
+```
+
+If your size is in millimetres, convert to inches first (divide by 25.4), then multiply by 300.
+
+## Common sizes at 300 DPI
+
+Here are the pixel sizes I use most often for standard paper:
+
+- **A4** (210 × 297 mm) → about **2480 × 3508 px**
+- **A3** (297 × 420 mm) → about **3508 × 4961 px**
+- **A2** (420 × 594 mm) → about **4961 × 7016 px**
+
+Generate or export at those dimensions and you’re print-ready at 300 DPI.
+
+## Already have a file?
+
+If the image already exists, divide its pixel width and height by 300.
+
+That gives you the largest size, in inches, where the print should still look sharp. If you need something bigger, regenerate at a higher resolution rather than stretching the file.
+
+## Takeaway
+
+Pick the print size first, then generate enough pixels to hit 300 DPI. That’s the cleanest way to keep digital work looking crisp on paper.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a new lean article explaining how to work out pixel dimensions from a chosen print size at 300 DPI
- Framed for generative art: pick the paper size first, then generate enough pixels
- No header image; includes A4 / A3 / A2 examples and the reverse check for existing files

## Test plan
- [ ] Open `/articles/print-size-pixels-300dpi` and confirm title, date, and sections render
- [ ] Confirm no header image is shown
- [ ] Confirm article appears on `/articles` index
- [ ] Spot-check A4 / A3 / A2 pixel numbers against inches × 300

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5b4ec34-bca8-4f4d-8443-2901f3b28e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5b4ec34-bca8-4f4d-8443-2901f3b28e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

